### PR TITLE
feat(videos): add Rutube-backed videos API and wire Videos page to it

### DIFF
--- a/json-server/index.js
+++ b/json-server/index.js
@@ -7,6 +7,7 @@ const https = require('https');
 const http = require('http');
 const { registerInstructionRoutes } = require('./instructions/instructions.routes');
 const { registerEirRoutes } = require('./eir/eir.routes');
+const { registerVideoRoutes } = require('./videos/videos.routes');
 
 const options = {
     key: fs.readFileSync(path.resolve(__dirname, 'server.key')),
@@ -52,8 +53,9 @@ server.post('/login', (req, res) => {
 // eslint-disable-next-line
 server.use((req, res, next) => {
     const publicInstructionRoute = req.path.startsWith('/api/instructions') || req.path.startsWith('/instructions');
+    const publicVideoRoute = req.path.startsWith('/api/videos/rutube') || req.path.startsWith('/videos/rutube');
 
-    if (publicInstructionRoute) {
+    if (publicInstructionRoute || publicVideoRoute) {
         return next();
     }
 
@@ -66,6 +68,7 @@ server.use((req, res, next) => {
 
 registerInstructionRoutes(server);
 registerEirRoutes(server);
+registerVideoRoutes(server);
 server.use(router);
 
 // запуск сервера

--- a/json-server/videos/types.ts
+++ b/json-server/videos/types.ts
@@ -1,0 +1,38 @@
+import { IncomingMessage } from 'http';
+
+export interface VideoDto {
+    id: string;
+    title: string;
+    link: string;
+    type: 'VIDEO_INSTRUCTION' | 'WEBINARS' | 'PLUGINS';
+    section: 'COMMON' | 'AR' | 'KR' | 'OV' | 'VK' | 'EL';
+    software: 'AUTOCAD' | 'REVIT' | 'TANGL_VALUE' | 'CIVIL3D';
+}
+
+export type RutubeCard = {
+    id?: string | number;
+    title?: string;
+    video_url?: string;
+    embed_url?: string;
+    absolute_url?: string;
+    category?: string;
+};
+
+export type RutubeResponse = {
+    results?: RutubeCard[];
+};
+
+export type JsonServerRequest = {
+    query: Record<string, string | string[] | undefined>;
+};
+
+export type JsonServerResponse = {
+    json: (body: unknown) => void;
+    status: (code: number) => JsonServerResponse;
+};
+
+export type JsonServerApp = {
+    get: (path: string, handler: (req: JsonServerRequest, res: JsonServerResponse) => Promise<void> | void) => void;
+};
+
+export type HttpGet = (url: string) => Promise<IncomingMessage>;

--- a/json-server/videos/types.ts
+++ b/json-server/videos/types.ts
@@ -1,5 +1,3 @@
-import { IncomingMessage } from 'http';
-
 export interface VideoDto {
     id: string;
     title: string;
@@ -18,8 +16,21 @@ export type RutubeCard = {
     category?: string;
 };
 
-export type RutubeResponse = {
-    results?: RutubeCard[];
+export type RutubePlaylist = {
+    id?: string | number;
+    title?: string;
+    name?: string;
+    videos?: Array<{ id?: string | number } | string | number>;
+    video_ids?: Array<string | number>;
+    videos_url?: string;
+    video_url?: string;
+    api_url?: string;
+    absolute_url?: string;
+};
+
+export type RutubeListResponse<T> = {
+    results?: T[];
+    next?: string | null;
 };
 
 export type JsonServerRequest = {
@@ -34,5 +45,3 @@ export type JsonServerResponse = {
 export type JsonServerApp = {
     get: (path: string, handler: (req: JsonServerRequest, res: JsonServerResponse) => Promise<void> | void) => void;
 };
-
-export type HttpGet = (url: string) => Promise<IncomingMessage>;

--- a/json-server/videos/videos.controller.ts
+++ b/json-server/videos/videos.controller.ts
@@ -1,0 +1,34 @@
+import { JsonServerRequest, JsonServerResponse, VideoDto } from './types';
+import { getVideos } from './videos.service';
+
+const SORT_FIELDS: Array<keyof VideoDto> = ['id', 'title', 'type', 'section', 'software', 'link'];
+
+export const getVideosController = async (req: JsonServerRequest, res: JsonServerResponse) => {
+    try {
+        const page = Number(req.query._page || req.query.page || 1);
+        const limit = Number(req.query._limit || req.query.limit || 9);
+        const search = String(req.query.q || req.query.search || '');
+        const requestedSort = String(req.query._sort || req.query.sort || 'title') as keyof VideoDto;
+        const sort = SORT_FIELDS.includes(requestedSort) ? requestedSort : 'title';
+        const requestedOrder = String(req.query._order || req.query.order || 'asc');
+        const order = requestedOrder === 'desc' ? 'desc' : 'asc';
+        const requestedType = req.query.type;
+        const type = typeof requestedType === 'string' && requestedType.length > 0
+            ? (requestedType as VideoDto['type'])
+            : undefined;
+
+        const videos = await getVideos({
+            page: Number.isFinite(page) && page > 0 ? page : 1,
+            limit: Number.isFinite(limit) && limit > 0 ? limit : 9,
+            search,
+            sort,
+            order,
+            type,
+        });
+
+        res.json(videos);
+    } catch (error) {
+        const message = error instanceof Error ? error.message : 'Unexpected videos API error';
+        res.status(500).json({ message });
+    }
+};

--- a/json-server/videos/videos.repository.ts
+++ b/json-server/videos/videos.repository.ts
@@ -1,12 +1,19 @@
 import fs from 'fs';
 import path from 'path';
 import { request as httpsRequest } from 'https';
-import { RutubeResponse, VideoDto } from './types';
+import { RutubeCard, RutubeListResponse, RutubePlaylist, VideoDto } from './types';
 
 const DEFAULT_TIMEOUT = 8000;
-const ENDPOINTS = [
+const MAX_PAGES = 200;
+
+const VIDEO_ENDPOINTS = [
     'https://rutube.ru/api/video/person/36353169/',
     'https://rutube.ru/api/video/userchannel/36353169/',
+];
+
+const PLAYLIST_ENDPOINTS = [
+    'https://rutube.ru/api/playlist/person/36353169/',
+    'https://rutube.ru/api/playlist/userchannel/36353169/',
 ];
 
 const fetchJson = async <T>(url: string): Promise<T> => new Promise((resolve, reject) => {
@@ -44,43 +51,188 @@ const fetchJson = async <T>(url: string): Promise<T> => new Promise((resolve, re
     request.end();
 });
 
-const mapResponseToVideos = (payload: RutubeResponse, page: number, limit: number): VideoDto[] => {
-    const cards = payload.results || [];
-
-    return cards.slice(0, limit).map((card, index) => {
-        const id = String(card.id || `rutube-${page}-${index}`);
-        const embedOrUrl = card.embed_url || card.video_url || card.absolute_url || '';
-        const link = embedOrUrl.startsWith('http') ? embedOrUrl : `https://rutube.ru${embedOrUrl}`;
-
-        return {
-            id,
-            title: card.title || `Видео ${id}`,
-            link,
-            type: 'VIDEO_INSTRUCTION',
-            section: 'COMMON',
-            software: 'REVIT',
-        };
-    });
-};
-
-export const getRutubeVideos = async (page: number, limit: number): Promise<VideoDto[]> => {
-    const queries = ENDPOINTS.map((endpoint) => fetchJson<RutubeResponse>(`${endpoint}?format=json&page=${page}`));
-    const results = await Promise.allSettled(queries);
-
-    const successful = results
-        .filter((item): item is PromiseFulfilledResult<RutubeResponse> => item.status === 'fulfilled')
-        .map((item) => mapResponseToVideos(item.value, page, limit))
-        .find((videos) => videos.length > 0);
-
-    if (successful) {
-        return successful;
+const normalizeApiUrl = (url: string): string => {
+    if (url.startsWith('http')) {
+        return url;
     }
 
-    const reasons = results
-        .filter((item): item is PromiseRejectedResult => item.status === 'rejected')
-        .map((item) => String(item.reason));
+    return `https://rutube.ru${url}`;
+};
 
-    throw new Error(reasons.join('; '));
+const appendFormatAndPage = (url: string, page: number): string => {
+    const divider = url.includes('?') ? '&' : '?';
+    return `${url}${divider}format=json&page=${page}`;
+};
+
+const fetchAllFromPagedEndpoint = async <T>(endpoint: string): Promise<T[]> => {
+    const allItems: T[] = [];
+
+    const fetchPage = async (page: number, nextUrl?: string | null): Promise<T[]> => {
+        if (page > MAX_PAGES) {
+            return [];
+        }
+
+        const url = nextUrl ? normalizeApiUrl(nextUrl) : appendFormatAndPage(endpoint, page);
+        const payload = await fetchJson<RutubeListResponse<T>>(url);
+        const current = payload.results || [];
+
+        if (current.length === 0) {
+            return [];
+        }
+
+        const nextItems = payload.next ? await fetchPage(page + 1, payload.next) : await fetchPage(page + 1);
+        return [...current, ...nextItems];
+    };
+
+    const items = await fetchPage(1);
+    allItems.push(...items);
+
+    return allItems;
+};
+
+const mapPlaylistNameToType = (name?: string): VideoDto['type'] => {
+    const normalized = (name || '').toLowerCase();
+
+    if (normalized.includes('плагин') || normalized.includes('plugin')) {
+        return 'PLUGINS';
+    }
+
+    if (normalized.includes('вебинар') || normalized.includes('webinar')) {
+        return 'WEBINARS';
+    }
+
+    return 'VIDEO_INSTRUCTION';
+};
+
+const mapVideoTitleToType = (title?: string): VideoDto['type'] => {
+    const normalized = (title || '').toLowerCase();
+
+    if (normalized.includes('плагин') || normalized.includes('plugin')) {
+        return 'PLUGINS';
+    }
+
+    if (normalized.includes('вебинар') || normalized.includes('webinar')) {
+        return 'WEBINARS';
+    }
+
+    return 'VIDEO_INSTRUCTION';
+};
+
+const extractPlaylistVideoIds = (playlist: RutubePlaylist): string[] => {
+    const fromVideoIds = (playlist.video_ids || []).map((id) => String(id));
+
+    const fromVideos = (playlist.videos || [])
+        .map((item) => {
+            if (typeof item === 'string' || typeof item === 'number') {
+                return String(item);
+            }
+
+            if (typeof item === 'object' && item && 'id' in item && item.id !== undefined) {
+                return String(item.id);
+            }
+
+            return '';
+        })
+        .filter(Boolean);
+
+    return [...fromVideoIds, ...fromVideos];
+};
+
+const buildPlaylistVideoEndpoints = (playlist: RutubePlaylist): string[] => {
+    const id = playlist.id ? String(playlist.id) : '';
+    const apiUrl = playlist.api_url ? normalizeApiUrl(playlist.api_url) : '';
+    const videosUrl = playlist.videos_url ? normalizeApiUrl(playlist.videos_url) : '';
+    const videoUrl = playlist.video_url ? normalizeApiUrl(playlist.video_url) : '';
+
+    const candidates = [
+        videosUrl,
+        videoUrl,
+        apiUrl ? `${apiUrl.replace(/\/$/, '')}/videos/` : '',
+        id ? `https://rutube.ru/api/playlist/custom/${id}/videos/` : '',
+        id ? `https://rutube.ru/api/playlist/${id}/videos/` : '',
+    ];
+
+    return candidates.filter(Boolean);
+};
+
+const collectPlaylistTypeMap = async (): Promise<Record<string, VideoDto['type']>> => {
+    const map: Record<string, VideoDto['type']> = {};
+
+    const playlistResponses = await Promise.allSettled(PLAYLIST_ENDPOINTS.map((endpoint) => fetchAllFromPagedEndpoint<RutubePlaylist>(endpoint)));
+
+    const playlists = playlistResponses
+        .filter((result): result is PromiseFulfilledResult<RutubePlaylist[]> => result.status === 'fulfilled')
+        .flatMap((result) => result.value);
+
+    const addToMap = (videoIds: string[], type: VideoDto['type']) => {
+        videoIds.forEach((videoId) => {
+            if (!map[videoId]) {
+                map[videoId] = type;
+            }
+        });
+    };
+
+    await Promise.all(playlists.map(async (playlist) => {
+        const type = mapPlaylistNameToType(playlist.title || playlist.name);
+
+        const inlineVideoIds = extractPlaylistVideoIds(playlist);
+        addToMap(inlineVideoIds, type);
+
+        if (inlineVideoIds.length > 0) {
+            return;
+        }
+
+        const endpoints = buildPlaylistVideoEndpoints(playlist);
+
+        const results = await Promise.allSettled(endpoints.map((endpoint) => fetchAllFromPagedEndpoint<RutubeCard>(endpoint)));
+
+        const ids = results
+            .filter((result): result is PromiseFulfilledResult<RutubeCard[]> => result.status === 'fulfilled')
+            .flatMap((result) => result.value)
+            .map((video) => (video.id !== undefined ? String(video.id) : ''))
+            .filter(Boolean);
+
+        addToMap(ids, type);
+    }));
+
+    return map;
+};
+
+const mapVideoCard = (card: RutubeCard, playlistTypeMap: Record<string, VideoDto['type']>, index: number): VideoDto => {
+    const id = String(card.id || `rutube-${index}`);
+    const embedOrUrl = card.embed_url || card.video_url || card.absolute_url || '';
+    const link = embedOrUrl.startsWith('http') ? embedOrUrl : `https://rutube.ru${embedOrUrl}`;
+
+    return {
+        id,
+        title: card.title || `Видео ${id}`,
+        link,
+        type: playlistTypeMap[id] || mapVideoTitleToType(card.title),
+        section: 'COMMON',
+        software: 'REVIT',
+    };
+};
+
+export const getRutubeVideos = async (): Promise<VideoDto[]> => {
+    const videoResponses = await Promise.allSettled(VIDEO_ENDPOINTS.map((endpoint) => fetchAllFromPagedEndpoint<RutubeCard>(endpoint)));
+
+    const cards = videoResponses
+        .filter((result): result is PromiseFulfilledResult<RutubeCard[]> => result.status === 'fulfilled')
+        .flatMap((result) => result.value);
+
+    if (cards.length === 0) {
+        const errors = videoResponses
+            .filter((result): result is PromiseRejectedResult => result.status === 'rejected')
+            .map((result) => String(result.reason));
+
+        throw new Error(errors.join('; '));
+    }
+
+    const playlistTypeMap = await collectPlaylistTypeMap().catch(() => ({}));
+
+    const dedupedCards = Array.from(new Map(cards.map((card, index) => [String(card.id || `idx-${index}`), card])).values());
+
+    return dedupedCards.map((card, index) => mapVideoCard(card, playlistTypeMap, index));
 };
 
 export const getFallbackVideos = (): VideoDto[] => {

--- a/json-server/videos/videos.repository.ts
+++ b/json-server/videos/videos.repository.ts
@@ -1,0 +1,91 @@
+import fs from 'fs';
+import path from 'path';
+import { request as httpsRequest } from 'https';
+import { RutubeResponse, VideoDto } from './types';
+
+const DEFAULT_TIMEOUT = 8000;
+const ENDPOINTS = [
+    'https://rutube.ru/api/video/person/36353169/',
+    'https://rutube.ru/api/video/userchannel/36353169/',
+];
+
+const fetchJson = async <T>(url: string): Promise<T> => new Promise((resolve, reject) => {
+    const request = httpsRequest(url, { method: 'GET', timeout: DEFAULT_TIMEOUT }, (response) => {
+        const chunks: Buffer[] = [];
+
+        response.on('data', (chunk) => {
+            chunks.push(Buffer.from(chunk));
+        });
+
+        response.on('end', () => {
+            const raw = Buffer.concat(chunks).toString('utf8');
+
+            if (response.statusCode && response.statusCode >= 400) {
+                reject(new Error(`Rutube API error ${response.statusCode}`));
+                return;
+            }
+
+            try {
+                resolve(JSON.parse(raw) as T);
+            } catch {
+                reject(new Error('Invalid Rutube API response'));
+            }
+        });
+    });
+
+    request.on('timeout', () => {
+        request.destroy(new Error('Rutube API timeout'));
+    });
+
+    request.on('error', (error) => {
+        reject(error);
+    });
+
+    request.end();
+});
+
+const mapResponseToVideos = (payload: RutubeResponse, page: number, limit: number): VideoDto[] => {
+    const cards = payload.results || [];
+
+    return cards.slice(0, limit).map((card, index) => {
+        const id = String(card.id || `rutube-${page}-${index}`);
+        const embedOrUrl = card.embed_url || card.video_url || card.absolute_url || '';
+        const link = embedOrUrl.startsWith('http') ? embedOrUrl : `https://rutube.ru${embedOrUrl}`;
+
+        return {
+            id,
+            title: card.title || `Видео ${id}`,
+            link,
+            type: 'VIDEO_INSTRUCTION',
+            section: 'COMMON',
+            software: 'REVIT',
+        };
+    });
+};
+
+export const getRutubeVideos = async (page: number, limit: number): Promise<VideoDto[]> => {
+    const queries = ENDPOINTS.map((endpoint) => fetchJson<RutubeResponse>(`${endpoint}?format=json&page=${page}`));
+    const results = await Promise.allSettled(queries);
+
+    const successful = results
+        .filter((item): item is PromiseFulfilledResult<RutubeResponse> => item.status === 'fulfilled')
+        .map((item) => mapResponseToVideos(item.value, page, limit))
+        .find((videos) => videos.length > 0);
+
+    if (successful) {
+        return successful;
+    }
+
+    const reasons = results
+        .filter((item): item is PromiseRejectedResult => item.status === 'rejected')
+        .map((item) => String(item.reason));
+
+    throw new Error(reasons.join('; '));
+};
+
+export const getFallbackVideos = (): VideoDto[] => {
+    const filePath = path.resolve(__dirname, '../db.json');
+    const raw = fs.readFileSync(filePath, 'utf8');
+    const db = JSON.parse(raw) as { videos?: VideoDto[] };
+    return db.videos || [];
+};

--- a/json-server/videos/videos.routes.ts
+++ b/json-server/videos/videos.routes.ts
@@ -1,0 +1,7 @@
+import { JsonServerApp } from './types';
+import { getVideosController } from './videos.controller';
+
+export const registerVideoRoutes = (app: JsonServerApp) => {
+    app.get('/api/videos/rutube', getVideosController);
+    app.get('/videos/rutube', getVideosController);
+};

--- a/json-server/videos/videos.service.ts
+++ b/json-server/videos/videos.service.ts
@@ -23,7 +23,7 @@ export const getVideos = async (params: QueryParams): Promise<VideoDto[]> => {
     let videos: VideoDto[] = [];
 
     try {
-        videos = await getRutubeVideos(page, limit);
+        videos = await getRutubeVideos();
     } catch {
         videos = getFallbackVideos();
     }

--- a/json-server/videos/videos.service.ts
+++ b/json-server/videos/videos.service.ts
@@ -1,0 +1,52 @@
+import { getFallbackVideos, getRutubeVideos } from './videos.repository';
+import { VideoDto } from './types';
+
+type QueryParams = {
+    page: number;
+    limit: number;
+    search: string;
+    sort: keyof VideoDto;
+    order: 'asc' | 'desc';
+    type?: VideoDto['type'];
+};
+
+export const getVideos = async (params: QueryParams): Promise<VideoDto[]> => {
+    const {
+        page,
+        limit,
+        search,
+        sort,
+        order,
+        type,
+    } = params;
+
+    let videos: VideoDto[] = [];
+
+    try {
+        videos = await getRutubeVideos(page, limit);
+    } catch {
+        videos = getFallbackVideos();
+    }
+
+    const normalizedSearch = search.trim().toLowerCase();
+
+    const filtered = videos.filter((video) => {
+        const byType = type ? video.type === type : true;
+        const bySearch = normalizedSearch.length > 0
+            ? video.title.toLowerCase().includes(normalizedSearch)
+            : true;
+
+        return byType && bySearch;
+    });
+
+    const sorted = filtered.sort((a, b) => {
+        const left = String(a[sort] || '').toLowerCase();
+        const right = String(b[sort] || '').toLowerCase();
+        const compareResult = left.localeCompare(right, 'ru');
+
+        return order === 'asc' ? compareResult : -compareResult;
+    });
+
+    const start = (page - 1) * limit;
+    return sorted.slice(start, start + limit);
+};

--- a/src/pages/VideosPage/model/services/fetchVideos/fetchVideos.ts
+++ b/src/pages/VideosPage/model/services/fetchVideos/fetchVideos.ts
@@ -53,7 +53,7 @@ export const fetchVideos = createAsyncThunk<Video[], fetchVideosProps, ThunkConf
                 search,
                 type: type === VideoType.ALL ? undefined : type,
             });
-            const response = await extra.api.get<Video[]>('/videos', {
+            const response = await extra.api.get<Video[]>('/api/videos/rutube', {
                 params,
             });
             if (!response.data) {


### PR DESCRIPTION
### Motivation
- Provide a backend endpoint that retrieves videos from Rutube for channel `36353169` so the Videos page no longer relies on hardcoded links.
- Keep site resilient when external access is blocked by falling back to local `db.json` data.
- Preserve existing frontend filtering/sorting/pagination behavior while enabling dynamic video loading.

### Description
- Added a new json-server module `json-server/videos` with `types.ts`, `videos.repository.ts`, `videos.service.ts`, `videos.controller.ts`, and `videos.routes.ts` to implement a Rutube-backed videos API.
- Implemented Rutube fetch logic that queries multiple candidate endpoints with `Promise.allSettled`, maps results to the app `VideoDto` shape, and throws to trigger a fallback when all external requests fail.
- Implemented a fallback that loads videos from the local `json-server/db.json` when Rutube requests are unavailable, and applied filtering, sorting and pagination in `videos.service.ts` to match frontend expectations.
- Registered the new routes at `/api/videos/rutube` and compatibility `/videos/rutube` in `json-server/index.js`, and marked them public (bypassing the auth middleware), and updated the frontend thunk in `src/pages/VideosPage/model/services/fetchVideos/fetchVideos.ts` to request from `/api/videos/rutube`.

### Testing
- Ran targeted lint for the new files with `npx eslint json-server/videos/*.ts src/pages/VideosPage/model/services/fetchVideos/fetchVideos.ts`, which completed successfully.
- Executed the service locally using `node -e "require('ts-node/register/transpile-only'); const { getVideos } = require('./json-server/videos/videos.service.ts'); getVideos({page:1,limit:3,search:'',sort:'title',order:'asc'}).then(v=>{console.log('videos',v.length); console.log(v[0]);}).catch(e=>{console.error(e); process.exit(1);});"` and it returned videos (successful).
- Running the full repository lint via `npm run lint:ts` still fails due to preexisting unrelated lint issues elsewhere in the repo (these are not caused by the new files).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c4b67c512483299ce6d34d4d5b262c)