### PR TITLE
Add manual RuTube refresh endpoint and Admin UI button; improve Rutube fetch/caching and NocoDB integration

### DIFF
--- a/json-server/index.js
+++ b/json-server/index.js
@@ -8,6 +8,7 @@ const http = require('http');
 const { registerInstructionRoutes } = require('./instructions/instructions.routes');
 const { registerEirRoutes } = require('./eir/eir.routes');
 const { registerVideoRoutes } = require('./videos/videos.routes');
+const { refreshRutubeVideosCache } = require('./videos/videos.repository');
 
 const options = {
     key: fs.readFileSync(path.resolve(__dirname, 'server.key')),
@@ -39,6 +40,7 @@ server.post('/login', (req, res) => {
         const userFromBd = users.find((user) => user.username === username && user.password === password);
 
         if (userFromBd) {
+            refreshRutubeVideosCache().catch(() => null);
             return res.json(userFromBd);
         }
 
@@ -53,7 +55,7 @@ server.post('/login', (req, res) => {
 // eslint-disable-next-line
 server.use((req, res, next) => {
     const publicInstructionRoute = req.path.startsWith('/api/instructions') || req.path.startsWith('/instructions');
-    const publicVideoRoute = req.path.startsWith('/api/videos/rutube') || req.path.startsWith('/videos/rutube');
+    const publicVideoRoute = req.path === '/api/videos/rutube' || req.path === '/videos/rutube';
 
     if (publicInstructionRoute || publicVideoRoute) {
         return next();

--- a/json-server/videos/types.ts
+++ b/json-server/videos/types.ts
@@ -44,4 +44,5 @@ export type JsonServerResponse = {
 
 export type JsonServerApp = {
     get: (path: string, handler: (req: JsonServerRequest, res: JsonServerResponse) => Promise<void> | void) => void;
+    post: (path: string, handler: (req: JsonServerRequest, res: JsonServerResponse) => Promise<void> | void) => void;
 };

--- a/json-server/videos/videos.controller.ts
+++ b/json-server/videos/videos.controller.ts
@@ -1,7 +1,11 @@
 import { JsonServerRequest, JsonServerResponse, VideoDto } from './types';
 import { getVideos } from './videos.service';
+import { getRutubeRefreshDiagnostics, refreshRutubeVideosCache } from './videos.repository';
 
 const SORT_FIELDS: Array<keyof VideoDto> = ['id', 'title', 'type', 'section', 'software', 'link'];
+const TYPE_VALUES: Array<VideoDto['type']> = ['VIDEO_INSTRUCTION', 'WEBINARS', 'PLUGINS'];
+const SECTION_VALUES: Array<VideoDto['section']> = ['COMMON', 'AR', 'KR', 'OV', 'VK', 'EL'];
+const SOFTWARE_VALUES: Array<VideoDto['software']> = ['AUTOCAD', 'REVIT', 'TANGL_VALUE', 'CIVIL3D'];
 
 export const getVideosController = async (req: JsonServerRequest, res: JsonServerResponse) => {
     try {
@@ -13,8 +17,28 @@ export const getVideosController = async (req: JsonServerRequest, res: JsonServe
         const requestedOrder = String(req.query._order || req.query.order || 'asc');
         const order = requestedOrder === 'desc' ? 'desc' : 'asc';
         const requestedType = req.query.type;
-        const type = typeof requestedType === 'string' && requestedType.length > 0
-            ? (requestedType as VideoDto['type'])
+        const requestedSection = req.query.section;
+        const requestedSoftware = req.query.software;
+        const requestedFilter = req.query.filter;
+        const validFilter = typeof requestedFilter === 'string' && requestedFilter.length > 0
+            ? requestedFilter
+            : undefined;
+        const typeCandidate = typeof requestedType === 'string' && requestedType.length > 0 ? requestedType : validFilter;
+        const sectionCandidate = typeof requestedSection === 'string' && requestedSection.length > 0
+            ? requestedSection
+            : validFilter;
+        const softwareCandidate = typeof requestedSoftware === 'string' && requestedSoftware.length > 0
+            ? requestedSoftware
+            : validFilter;
+
+        const type = typeCandidate && TYPE_VALUES.includes(typeCandidate as VideoDto['type'])
+            ? (typeCandidate as VideoDto['type'])
+            : undefined;
+        const section = sectionCandidate && SECTION_VALUES.includes(sectionCandidate as VideoDto['section'])
+            ? (sectionCandidate as VideoDto['section'])
+            : undefined;
+        const software = softwareCandidate && SOFTWARE_VALUES.includes(softwareCandidate as VideoDto['software'])
+            ? (softwareCandidate as VideoDto['software'])
             : undefined;
 
         const videos = await getVideos({
@@ -24,11 +48,29 @@ export const getVideosController = async (req: JsonServerRequest, res: JsonServe
             sort,
             order,
             type,
+            section,
+            software,
         });
 
         res.json(videos);
     } catch (error) {
         const message = error instanceof Error ? error.message : 'Unexpected videos API error';
         res.status(500).json({ message });
+    }
+};
+
+export const refreshVideosController = async (_req: JsonServerRequest, res: JsonServerResponse) => {
+    try {
+        const videos = await refreshRutubeVideosCache();
+
+        res.json({
+            success: true,
+            count: videos.length,
+            updatedAt: Date.now(),
+            diagnostics: getRutubeRefreshDiagnostics(),
+        });
+    } catch (error) {
+        const message = error instanceof Error ? error.message : 'Unexpected videos refresh error';
+        res.status(500).json({ success: false, message });
     }
 };

--- a/json-server/videos/videos.repository.ts
+++ b/json-server/videos/videos.repository.ts
@@ -6,13 +6,20 @@ import { RutubeCard, RutubeListResponse, RutubePlaylist, VideoDto } from './type
 const DEFAULT_TIMEOUT = 8000;
 const MAX_PAGES = 200;
 const CHANNEL_VIDEOS_URL = 'https://rutube.ru/channel/36353169/videos/';
-const CACHE_TTL_MS = 24 * 60 * 60 * 1000;
-const REFRESH_INTERVAL_MS = 24 * 60 * 60 * 1000;
+const CHANNEL_ID = '36353169';
+const CHANNEL_FEED_URLS = [
+    `https://rutube.ru/feeds/video/${CHANNEL_ID}/`,
+    `https://rutube.ru/feeds/video/${CHANNEL_ID}.rss`,
+    `https://rutube.ru/channel/${CHANNEL_ID}/video/rss/`,
+];
+const CACHE_TTL_MS = 12 * 60 * 60 * 1000;
+const REFRESH_INTERVAL_MS = 12 * 60 * 60 * 1000;
 const CACHE_FILE_PATH = path.resolve(__dirname, 'videos-cache.json');
 
 let cachedVideos: VideoDto[] | null = null;
 let cacheTimestamp = 0;
 let inFlightVideosPromise: Promise<VideoDto[]> | null = null;
+let lastRefreshDiagnostics: Record<string, unknown> = {};
 
 const VIDEO_ENDPOINTS = [
     'https://rutube.ru/api/video/person/36353169/',
@@ -23,6 +30,11 @@ const PLAYLIST_ENDPOINTS = [
     'https://rutube.ru/api/playlist/person/36353169/',
     'https://rutube.ru/api/playlist/userchannel/36353169/',
 ];
+const NOCODB_BASE_URL = String(process.env.NOCODB_BASE_URL || 'http://tim.atomsk.ru:3000').replace(/\/$/, '');
+const NOCODB_TABLE_ID = String(process.env.NOCODB_TABLE_ID || 'm2jcg5rzheaqlxw');
+const NOCODB_VIEW_ID = String(process.env.NOCODB_VIEW_ID || 'vwqbdsi0ekspi90b');
+const NOCODB_TOKEN = String(process.env.NOCODB_TOKEN || process.env.NOCODB_API_TOKEN || '');
+const NOCODB_LIMIT = 200;
 
 const readVideosCacheFromDisk = (): { videos: VideoDto[]; updatedAt: number } | null => {
     try {
@@ -112,6 +124,26 @@ const fetchJson = async <T>(url: string): Promise<T> => {
     }
 };
 
+const fetchNocoDbJson = async <T>(url: string): Promise<T> => {
+    const headers: Record<string, string> = {
+        Accept: 'application/json',
+    };
+
+    if (NOCODB_TOKEN) {
+        headers['xc-token'] = NOCODB_TOKEN;
+    }
+
+    const response = await fetch(url, {
+        headers,
+    });
+
+    if (!response.ok) {
+        throw new Error(`NocoDB API error ${response.status}`);
+    }
+
+    return response.json() as Promise<T>;
+};
+
 const normalizeApiUrl = (url: string): string => {
     if (url.startsWith('http')) {
         return url;
@@ -125,25 +157,103 @@ const appendFormatAndPage = (url: string, page: number): string => {
     return `${url}${divider}format=json&page=${page}`;
 };
 
-const fetchAllFromPagedEndpoint = async <T>(endpoint: string): Promise<T[]> => {
-    const fetchPage = async (page: number, nextUrl?: string | null): Promise<T[]> => {
-        if (page > MAX_PAGES) {
-            return [];
-        }
+const extractCollectionFromPayload = <T>(payload: unknown): { items: T[]; next?: string | null } => {
+    if (!payload || typeof payload !== 'object') {
+        return { items: [] };
+    }
 
+    const source = payload as Record<string, unknown>;
+    const nestedData = (source.data && typeof source.data === 'object' ? source.data : {}) as Record<string, unknown>;
+    const nestedPayload = (source.payload && typeof source.payload === 'object' ? source.payload : {}) as Record<string, unknown>;
+
+    const candidates: unknown[] = [
+        source.results,
+        source.items,
+        source.videos,
+        source.video_list,
+        nestedData.results,
+        nestedData.items,
+        nestedData.videos,
+        nestedData.video_list,
+        nestedPayload.results,
+        nestedPayload.items,
+        nestedPayload.videos,
+    ];
+    const itemsCandidate = candidates.find(Array.isArray);
+    const items = Array.isArray(itemsCandidate) ? (itemsCandidate as T[]) : [];
+
+    const nextCandidate = source.next
+        || nestedData.next
+        || nestedPayload.next
+        || (source.pagination && typeof source.pagination === 'object' ? (source.pagination as Record<string, unknown>).next : undefined)
+        || (source.paging && typeof source.paging === 'object' ? (source.paging as Record<string, unknown>).next : undefined);
+
+    return {
+        items,
+        next: typeof nextCandidate === 'string' || nextCandidate === null ? nextCandidate : undefined,
+    };
+};
+
+const getItemSignature = (item: unknown): string => {
+    if (typeof item === 'object' && item) {
+        const itemAsRecord = item as Record<string, unknown>;
+        const id = itemAsRecord.id ?? itemAsRecord.uuid ?? itemAsRecord.pk;
+        const title = itemAsRecord.title ?? itemAsRecord.name;
+
+        if (id !== undefined || title !== undefined) {
+            return `${String(id ?? '')}:${String(title ?? '')}`;
+        }
+    }
+
+    return JSON.stringify(item);
+};
+
+const fetchAllFromPagedEndpoint = async <T>(endpoint: string): Promise<T[]> => {
+    const items: T[] = [];
+    const seenItemSignatures = new Set<string>();
+    const seenPageSignatures = new Set<string>();
+    let page = 1;
+    let nextUrl: string | null | undefined;
+
+    while (page <= MAX_PAGES) {
         const url = nextUrl ? normalizeApiUrl(nextUrl) : appendFormatAndPage(endpoint, page);
+        // eslint-disable-next-line no-await-in-loop
         const payload = await fetchJson<RutubeListResponse<T>>(url);
-        const current = payload.results || [];
+        const collection = extractCollectionFromPayload<T>(payload);
+        const current = collection.items;
 
         if (current.length === 0) {
-            return [];
+            break;
         }
 
-        const nextItems = payload.next ? await fetchPage(page + 1, payload.next) : await fetchPage(page + 1);
-        return [...current, ...nextItems];
-    };
+        const pageSignature = current.map(getItemSignature).join('|');
+        if (seenPageSignatures.has(pageSignature)) {
+            break;
+        }
+        seenPageSignatures.add(pageSignature);
 
-    return fetchPage(1);
+        let hasNewItems = false;
+
+        current.forEach((item) => {
+            const signature = getItemSignature(item);
+
+            if (!seenItemSignatures.has(signature)) {
+                seenItemSignatures.add(signature);
+                items.push(item);
+                hasNewItems = true;
+            }
+        });
+
+        nextUrl = collection.next;
+
+        if (!nextUrl && !hasNewItems) {
+            break;
+        }
+
+        page += 1;
+    }
+
+    return items;
 };
 
 const decodeHtml = (value: string): string =>
@@ -152,6 +262,47 @@ const decodeHtml = (value: string): string =>
         .replace(/&quot;/g, '"')
         .replace(/&#39;/g, "'")
         .replace(/&amp;/g, '&');
+
+const decodeJsEscapes = (value: string): string =>
+    value
+        .replace(/\\x([0-9a-fA-F]{2})/g, (_, hex: string) => String.fromCharCode(parseInt(hex, 16)))
+        .replace(/\\u([0-9a-fA-F]{4})/g, (_, hex: string) => String.fromCharCode(parseInt(hex, 16)));
+
+const normalizeEndpointCandidate = (value: string): string => {
+    const decoded = decodeJsEscapes(decodeHtml(value))
+        .replace(/\\\//g, '/')
+        .trim();
+    const withDomain = decoded.startsWith('http') ? decoded : `https://rutube.ru${decoded}`;
+
+    return withDomain
+        .replace(/([?&])format=json(&|$)/g, '$1')
+        .replace(/([?&])page=\d+(&|$)/g, '$1')
+        .replace(/[?&]$/, '')
+        .replace(/\?&/, '?');
+};
+
+const extractApiVideoEndpointsFromHtml = (html: string): string[] => {
+    const decodedHtml = decodeHtml(html).replace(/\\\//g, '/');
+    const rawMatches = Array.from(
+        decodedHtml.matchAll(/((?:https?:\/\/rutube\.ru)?\/api\/[^"'\s<]+)/gi),
+    ).map((match) => match[1]);
+
+    const candidates = rawMatches
+        .map(normalizeEndpointCandidate)
+        .filter((url) => {
+            if (!url.includes('/api/')) {
+                return false;
+            }
+
+            if (url.includes('/api/ads') || url.includes('/api/oauth') || url.includes('/api/auth')) {
+                return false;
+            }
+
+            return true;
+        });
+
+    return Array.from(new Set(candidates));
+};
 
 const extractCardsFromChannelHtml = (html: string): RutubeCard[] => {
     const titleById: Record<string, string> = {};
@@ -184,26 +335,177 @@ const extractCardsFromChannelHtml = (html: string): RutubeCard[] => {
     }));
 };
 
+const decodeXmlEntities = (value: string): string =>
+    value
+        .replace(/&quot;/g, '"')
+        .replace(/&#39;/g, "'")
+        .replace(/&amp;/g, '&')
+        .replace(/&lt;/g, '<')
+        .replace(/&gt;/g, '>');
+
+const extractCardsFromFeedXml = (xml: string): RutubeCard[] => {
+    const cards: RutubeCard[] = [];
+    const itemPattern = /<item\b[\s\S]*?<\/item>/gi;
+    const items = xml.match(itemPattern) || [];
+
+    items.forEach((item, index) => {
+        const titleMatch = item.match(/<title>(?:<!\[CDATA\[)?([\s\S]*?)(?:\]\]>)?<\/title>/i);
+        const linkMatch = item.match(/<link>([\s\S]*?)<\/link>/i);
+        const guidMatch = item.match(/<guid[^>]*>([\s\S]*?)<\/guid>/i);
+        const sourceLink = linkMatch?.[1] || guidMatch?.[1] || '';
+        const idMatch = sourceLink.match(/\/video\/([a-f0-9]{32})\/?/i);
+        const id = idMatch?.[1];
+
+        if (!id) {
+            return;
+        }
+
+        const rawTitle = (titleMatch?.[1] || `Видео ${id}`).trim();
+        const title = decodeXmlEntities(rawTitle.replace(/<!\[CDATA\[|\]\]>/g, ''));
+
+        cards.push({
+            id,
+            title,
+            embed_url: `/play/embed/${id}`,
+        });
+    });
+
+    return Array.from(new Map(cards.map((card, index) => [String(card.id || `feed-${index}`), card])).values());
+};
+
 const getChannelVideosByHtml = async (): Promise<RutubeCard[]> => {
-    const fetchPages = async (page: number): Promise<RutubeCard[]> => {
-        if (page > MAX_PAGES) {
-            return [];
-        }
+    const cards: RutubeCard[] = [];
+    const seenIds = new Set<string>();
 
+    for (let page = 1; page <= MAX_PAGES; page += 1) {
+        // eslint-disable-next-line no-await-in-loop
         const html = await fetchRaw(`${CHANNEL_VIDEOS_URL}?page=${page}`);
-        const cards = extractCardsFromChannelHtml(html);
+        const pageCards = extractCardsFromChannelHtml(html);
 
-        if (cards.length === 0) {
-            return [];
+        if (pageCards.length === 0) {
+            break;
         }
 
-        const next = await fetchPages(page + 1);
-        return [...cards, ...next];
+        let hasNewCards = false;
+
+        pageCards.forEach((card, index) => {
+            const id = String(card.id || `idx-${page}-${index}`);
+
+            if (!seenIds.has(id)) {
+                seenIds.add(id);
+                cards.push(card);
+                hasNewCards = true;
+            }
+        });
+
+        if (!hasNewCards) {
+            break;
+        }
+    }
+
+    return cards;
+};
+
+const getDiscoveredApiCardsFromChannelHtml = async (): Promise<{ cards: RutubeCard[]; endpoints: string[] }> => {
+    const html = await fetchRaw(CHANNEL_VIDEOS_URL);
+    const discoveredEndpoints = extractApiVideoEndpointsFromHtml(html);
+
+    if (discoveredEndpoints.length === 0) {
+        return { cards: [], endpoints: [] };
+    }
+
+    const endpointResponses = await Promise.allSettled(
+        discoveredEndpoints.map((endpoint) => fetchAllFromPagedEndpoint<RutubeCard>(endpoint)),
+    );
+
+    const cards = endpointResponses
+        .filter((result): result is PromiseFulfilledResult<RutubeCard[]> => result.status === 'fulfilled')
+        .flatMap((result) => result.value);
+
+    return {
+        cards,
+        endpoints: discoveredEndpoints,
     };
+};
 
-    const cards = await fetchPages(1);
+const extractNocoDbRows = (payload: unknown): Array<Record<string, unknown>> => {
+    if (!payload || typeof payload !== 'object') {
+        return [];
+    }
 
-    return Array.from(new Map(cards.map((card, index) => [String(card.id || `idx-${index}`), card])).values());
+    const source = payload as Record<string, unknown>;
+    const candidates = [source.list, source.records, source.items, source.results];
+    const list = candidates.find(Array.isArray);
+
+    return Array.isArray(list) ? (list as Array<Record<string, unknown>>) : [];
+};
+
+const extractNocoDbCard = (row: Record<string, unknown>, index: number): RutubeCard | null => {
+    const stringValues = Object.values(row).filter((value): value is string => typeof value === 'string');
+    const link = stringValues.find((value) => value.includes('rutube.ru/video/') || value.includes('/play/embed/'));
+
+    if (!link) {
+        return null;
+    }
+
+    const idMatch = link.match(/\/video\/([a-f0-9]{32})\/?/i) || link.match(/\/embed\/([a-f0-9]{32})\/?/i);
+    const idFromRow = typeof row.id === 'number' || typeof row.id === 'string' ? String(row.id) : undefined;
+    const title = (typeof row['Инструкция'] === 'string' && row['Инструкция'])
+        || (typeof row.title === 'string' && row.title)
+        || stringValues.find((value) => !value.startsWith('http'))
+        || `Видео ${idFromRow || index}`;
+
+    return {
+        id: idMatch?.[1] || idFromRow || `nocodb-${index}`,
+        title,
+        video_url: link,
+    };
+};
+
+const getCardsFromNocoDb = async (): Promise<RutubeCard[]> => {
+    if (!NOCODB_BASE_URL || !NOCODB_TABLE_ID) {
+        return [];
+    }
+
+    let offset = 0;
+    let hasMore = true;
+    const cards: RutubeCard[] = [];
+
+    while (hasMore) {
+        const query = new URLSearchParams({
+            limit: String(NOCODB_LIMIT),
+            offset: String(offset),
+            viewId: NOCODB_VIEW_ID,
+        });
+        const url = `${NOCODB_BASE_URL}/api/v2/tables/${NOCODB_TABLE_ID}/records?${query.toString()}`;
+        // eslint-disable-next-line no-await-in-loop
+        const payload = await fetchNocoDbJson<unknown>(url);
+        const rows = extractNocoDbRows(payload);
+
+        for (let index = 0; index < rows.length; index += 1) {
+            const row = rows[index];
+            const card = extractNocoDbCard(row, offset + index);
+
+            if (card) {
+                cards.push(card);
+            }
+        }
+
+        hasMore = rows.length === NOCODB_LIMIT;
+        offset += NOCODB_LIMIT;
+    }
+
+    return Array.from(new Map(cards.map((card, index) => [String(card.id || `nocodb-${index}`), card])).values());
+};
+
+const getChannelVideosByFeed = async (): Promise<RutubeCard[]> => {
+    const responses = await Promise.allSettled(CHANNEL_FEED_URLS.map((feedUrl) => fetchRaw(feedUrl)));
+
+    const cards = responses
+        .filter((result): result is PromiseFulfilledResult<string> => result.status === 'fulfilled')
+        .flatMap((result) => extractCardsFromFeedXml(result.value));
+
+    return Array.from(new Map(cards.map((card, index) => [String(card.id || `feed-${index}`), card])).values());
 };
 
 const mapPlaylistNameToType = (name?: string): VideoDto['type'] => {
@@ -271,8 +573,14 @@ const buildPlaylistVideoEndpoints = (playlist: RutubePlaylist): string[] => {
     return candidates.filter(Boolean);
 };
 
-const collectPlaylistTypeMap = async (): Promise<Record<string, VideoDto['type']>> => {
-    const map: Record<string, VideoDto['type']> = {};
+type PlaylistCollectionResult = {
+    typeMap: Record<string, VideoDto['type']>;
+    cards: RutubeCard[];
+};
+
+const collectPlaylistData = async (): Promise<PlaylistCollectionResult> => {
+    const typeMap: Record<string, VideoDto['type']> = {};
+    const cardsById = new Map<string, RutubeCard>();
 
     const playlistResponses = await Promise.allSettled(
         PLAYLIST_ENDPOINTS.map((endpoint) => fetchAllFromPagedEndpoint<RutubePlaylist>(endpoint)),
@@ -284,8 +592,8 @@ const collectPlaylistTypeMap = async (): Promise<Record<string, VideoDto['type']
 
     const addToMap = (videoIds: string[], type: VideoDto['type']) => {
         videoIds.forEach((videoId) => {
-            if (!map[videoId]) {
-                map[videoId] = type;
+            if (!typeMap[videoId]) {
+                typeMap[videoId] = type;
             }
         });
     };
@@ -296,6 +604,15 @@ const collectPlaylistTypeMap = async (): Promise<Record<string, VideoDto['type']
 
             const inlineVideoIds = extractPlaylistVideoIds(playlist);
             addToMap(inlineVideoIds, type);
+            inlineVideoIds.forEach((videoId) => {
+                if (!cardsById.has(videoId)) {
+                    cardsById.set(videoId, {
+                        id: videoId,
+                        title: `Видео ${videoId}`,
+                        embed_url: `/play/embed/${videoId}`,
+                    });
+                }
+            });
 
             if (inlineVideoIds.length > 0) {
                 return;
@@ -310,56 +627,99 @@ const collectPlaylistTypeMap = async (): Promise<Record<string, VideoDto['type']
             const ids = results
                 .filter((result): result is PromiseFulfilledResult<RutubeCard[]> => result.status === 'fulfilled')
                 .flatMap((result) => result.value)
-                .map((video) => (video.id !== undefined ? String(video.id) : ''))
+                .map((video) => {
+                    const id = video.id !== undefined ? String(video.id) : '';
+
+                    if (id && !cardsById.has(id)) {
+                        cardsById.set(id, video);
+                    }
+
+                    return id;
+                })
                 .filter(Boolean);
 
             addToMap(ids, type);
         }),
     );
 
-    return map;
+    return {
+        typeMap,
+        cards: Array.from(cardsById.values()),
+    };
 };
 
 const mapVideoCard = (card: RutubeCard, playlistTypeMap: Record<string, VideoDto['type']>, index: number): VideoDto => {
-    const id = String(card.id || `rutube-${index}`);
+    const fallbackCard = card as RutubeCard & Record<string, unknown>;
+    const id = String(card.id || fallbackCard.pk || fallbackCard.uuid || fallbackCard.video_id || `rutube-${index}`);
+    const titleSource = card.title || (typeof fallbackCard.name === 'string' ? fallbackCard.name : undefined);
     const embedOrUrl = card.embed_url || card.video_url || card.absolute_url || `/play/embed/${id}`;
     const link = embedOrUrl.startsWith('http') ? embedOrUrl : `https://rutube.ru${embedOrUrl}`;
 
     return {
         id,
-        title: card.title || `Видео ${id}`,
+        title: titleSource || `Видео ${id}`,
         link,
-        type: playlistTypeMap[id] || mapVideoTitleToType(card.title),
+        type: playlistTypeMap[id] || mapVideoTitleToType(titleSource),
         section: 'COMMON',
         software: 'REVIT',
     };
 };
 
 async function loadFreshRutubeVideos(): Promise<VideoDto[]> {
-    const videoResponses = await Promise.allSettled(
-        VIDEO_ENDPOINTS.map((endpoint) => fetchAllFromPagedEndpoint<RutubeCard>(endpoint)),
-    );
-    const htmlCardsPromise = getChannelVideosByHtml();
-
-    const apiCards = videoResponses
-        .filter((result): result is PromiseFulfilledResult<RutubeCard[]> => result.status === 'fulfilled')
-        .flatMap((result) => result.value);
-    const htmlCards = await htmlCardsPromise.catch(() => []);
-    const cards = [...apiCards, ...htmlCards];
+    const nocoCards = await getCardsFromNocoDb().catch(() => []);
+    let apiCards: RutubeCard[] = [];
+    let htmlCards: RutubeCard[] = [];
+    let discoveredApiCards: RutubeCard[] = [];
+    let feedCards: RutubeCard[] = [];
+    let discoveredEndpoints: string[] = [];
+    let cards: RutubeCard[] = nocoCards;
 
     if (cards.length === 0) {
-        const errors = videoResponses
-            .filter((result): result is PromiseRejectedResult => result.status === 'rejected')
-            .map((result) => String(result.reason));
+        const videoResponses = await Promise.allSettled(
+            VIDEO_ENDPOINTS.map((endpoint) => fetchAllFromPagedEndpoint<RutubeCard>(endpoint)),
+        );
+        const htmlCardsPromise = getChannelVideosByHtml();
+        const discoveredApiCardsPromise = getDiscoveredApiCardsFromChannelHtml();
+        const feedCardsPromise = getChannelVideosByFeed();
 
-        throw new Error(errors.join('; '));
+        apiCards = videoResponses
+            .filter((result): result is PromiseFulfilledResult<RutubeCard[]> => result.status === 'fulfilled')
+            .flatMap((result) => result.value);
+        htmlCards = await htmlCardsPromise.catch(() => []);
+        const discoveredApi = await discoveredApiCardsPromise.catch(() => ({ cards: [], endpoints: [] }));
+        discoveredApiCards = discoveredApi.cards;
+        discoveredEndpoints = discoveredApi.endpoints;
+        feedCards = await feedCardsPromise.catch(() => []);
+        cards = [...apiCards, ...htmlCards, ...discoveredApiCards, ...feedCards];
     }
 
-    const playlistTypeMap = await collectPlaylistTypeMap().catch(() => ({}));
+    if (cards.length === 0) {
+        throw new Error('No videos found in NocoDB or Rutube sources');
+    }
+
+    const playlistData = await collectPlaylistData().catch<PlaylistCollectionResult>(() => ({
+        typeMap: {},
+        cards: [],
+    }));
     const dedupedCards = Array.from(
-        new Map(cards.map((card, index) => [String(card.id || `idx-${index}`), card])).values(),
+        new Map([...cards, ...playlistData.cards].map((card, index) => [String(card.id || `idx-${index}`), card])).values(),
     );
-    const videos = dedupedCards.map((card, index) => mapVideoCard(card, playlistTypeMap, index));
+    const videos = dedupedCards.map((card, index) => mapVideoCard(card, playlistData.typeMap, index));
+
+    lastRefreshDiagnostics = {
+        updatedAt: Date.now(),
+        sourceCounts: {
+            nocoCards: nocoCards.length,
+            apiCards: apiCards.length,
+            htmlCards: htmlCards.length,
+            discoveredApiCards: discoveredApiCards.length,
+            feedCards: feedCards.length,
+            playlistCards: playlistData.cards.length,
+            totalBeforeDedupe: cards.length + playlistData.cards.length,
+            totalAfterDedupe: dedupedCards.length,
+        },
+        discoveredEndpoints,
+    };
 
     cachedVideos = videos;
     cacheTimestamp = Date.now();
@@ -412,6 +772,20 @@ export const getRutubeVideos = async (): Promise<VideoDto[]> => {
 
     return inFlightVideosPromise;
 };
+
+export const refreshRutubeVideosCache = async (): Promise<VideoDto[]> => {
+    if (inFlightVideosPromise) {
+        return inFlightVideosPromise;
+    }
+
+    inFlightVideosPromise = loadFreshRutubeVideos().finally(() => {
+        inFlightVideosPromise = null;
+    });
+
+    return inFlightVideosPromise;
+};
+
+export const getRutubeRefreshDiagnostics = () => lastRefreshDiagnostics;
 
 export const getFallbackVideos = (): VideoDto[] => {
     const filePath = path.resolve(__dirname, '../db.json');

--- a/json-server/videos/videos.routes.ts
+++ b/json-server/videos/videos.routes.ts
@@ -1,7 +1,9 @@
 import { JsonServerApp } from './types';
-import { getVideosController } from './videos.controller';
+import { getVideosController, refreshVideosController } from './videos.controller';
 
 export const registerVideoRoutes = (app: JsonServerApp) => {
     app.get('/api/videos/rutube', getVideosController);
     app.get('/videos/rutube', getVideosController);
+    app.post('/api/videos/rutube/refresh', refreshVideosController);
+    app.post('/videos/rutube/refresh', refreshVideosController);
 };

--- a/json-server/videos/videos.service.ts
+++ b/json-server/videos/videos.service.ts
@@ -8,6 +8,8 @@ type QueryParams = {
     sort: keyof VideoDto;
     order: 'asc' | 'desc';
     type?: VideoDto['type'];
+    section?: VideoDto['section'];
+    software?: VideoDto['software'];
 };
 
 export const getVideos = async (params: QueryParams): Promise<VideoDto[]> => {
@@ -18,6 +20,8 @@ export const getVideos = async (params: QueryParams): Promise<VideoDto[]> => {
         sort,
         order,
         type,
+        section,
+        software,
     } = params;
 
     let videos: VideoDto[] = [];
@@ -39,11 +43,13 @@ export const getVideos = async (params: QueryParams): Promise<VideoDto[]> => {
 
     const filtered = videos.filter((video) => {
         const byType = type ? video.type === type : true;
+        const bySection = section ? video.section === section : true;
+        const bySoftware = software ? video.software === software : true;
         const bySearch = normalizedSearch.length > 0
             ? video.title.toLowerCase().includes(normalizedSearch)
             : true;
 
-        return byType && bySearch;
+        return byType && bySection && bySoftware && bySearch;
     });
 
     const sorted = filtered.sort((a, b) => {

--- a/src/pages/AdminPanelPage/ui/AdminPanelPage.module.scss
+++ b/src/pages/AdminPanelPage/ui/AdminPanelPage.module.scss
@@ -1,3 +1,12 @@
 .AdminPanelPage {
-    /* Ваши стили */
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+}
+
+.refreshVideos {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 8px;
 }

--- a/src/pages/AdminPanelPage/ui/AdminPanelPage.tsx
+++ b/src/pages/AdminPanelPage/ui/AdminPanelPage.tsx
@@ -1,10 +1,63 @@
-import { memo } from 'react';
+import { memo, useCallback, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { useSelector } from 'react-redux';
+import { isUserAdmin } from '@/entities/User';
+import { $api } from '@/shared/config/api/api';
+import { Button } from '@/shared/ui/redesigned/Button';
+import { Text } from '@/shared/ui/redesigned/Text';
 import { Page } from '@/shared/ui/deprecated/Page';
+import cls from './AdminPanelPage.module.scss';
+
+interface RefreshVideosResponse {
+    success: boolean;
+    count?: number;
+    updatedAt?: number;
+    message?: string;
+}
 
 const AdminPanelPage = memo(() => {
     const { t } = useTranslation();
-    return <Page data-testid="AdminPanelPage">{t('AdminPanelPage')}</Page>;
+    const [isRefreshing, setIsRefreshing] = useState(false);
+    const [refreshError, setRefreshError] = useState<string | null>(null);
+    const [refreshSuccess, setRefreshSuccess] = useState<string | null>(null);
+    const canRefreshVideos = useSelector(isUserAdmin);
+
+    const onRefreshVideos = useCallback(async () => {
+        setIsRefreshing(true);
+        setRefreshError(null);
+        setRefreshSuccess(null);
+
+        try {
+            const response = await $api.post<RefreshVideosResponse>('/api/videos/rutube/refresh');
+
+            if (response.data.success) {
+                const count = response.data.count ?? 0;
+                setRefreshSuccess(t('Кеш видео обновлен. Найдено видео: {{count}}', { count }));
+            } else {
+                setRefreshError(response.data.message || t('Не удалось обновить кеш видео'));
+            }
+        } catch (error) {
+            const message = error instanceof Error ? error.message : t('Не удалось обновить кеш видео');
+            setRefreshError(message);
+        } finally {
+            setIsRefreshing(false);
+        }
+    }, [t]);
+
+    return (
+        <Page data-testid="AdminPanelPage" className={cls.AdminPanelPage}>
+            <Text title={t('AdminPanelPage')} />
+            {canRefreshVideos && (
+                <div className={cls.refreshVideos}>
+                    <Button onClick={onRefreshVideos} disabled={isRefreshing}>
+                        {isRefreshing ? t('Обновляем видео...') : t('Обновить видео с RuTube')}
+                    </Button>
+                    {refreshSuccess && <Text text={refreshSuccess} />}
+                    {refreshError && <Text variant="error" text={refreshError} />}
+                </div>
+            )}
+        </Page>
+    );
 });
 
 export default AdminPanelPage;

--- a/src/pages/VideosPage/model/services/fetchVideos/fetchVideos.ts
+++ b/src/pages/VideosPage/model/services/fetchVideos/fetchVideos.ts
@@ -3,7 +3,7 @@ import { ThunkConfig } from '@/shared/config/state';
 import { addQueryParams } from '@/shared/lib/url/addQueryParams/addQueryParams';
 import { SortOrder } from '@/shared/types/sort';
 
-import { Video, VideoFilterType, VideoSortField, VideoType } from '@/entities/Video';
+import { Video, VideoFilterType, VideoMainSections, VideoSoftware, VideoSortField, VideoType } from '@/entities/Video';
 import {
     getFilterSelectorOrder,
     getFilterSelectorSearch,
@@ -22,8 +22,32 @@ type VideosQuery = {
     _sort: VideoSortField;
     _order: SortOrder;
     q: string;
-    filter: VideoFilterType | undefined;
+    type?: VideoType;
+    section?: VideoMainSections;
+    software?: VideoSoftware;
 };
+
+const TYPE_VALUES: VideoType[] = [VideoType.VIDEO_INSTRUCTION, VideoType.WEBINARS, VideoType.PLUGINS];
+const SECTION_VALUES: VideoMainSections[] = [
+    VideoMainSections.COMMON,
+    VideoMainSections.AR,
+    VideoMainSections.KR,
+    VideoMainSections.OV,
+    VideoMainSections.VK,
+    VideoMainSections.EL,
+];
+const SOFTWARE_VALUES: VideoSoftware[] = [
+    VideoSoftware.AUTOCAD,
+    VideoSoftware.REVIT,
+    VideoSoftware.TANGL_VALUE,
+    VideoSoftware.CIVIL3D,
+];
+
+const isVideoType = (value: VideoFilterType): value is VideoType => TYPE_VALUES.includes(value as VideoType);
+const isVideoSection = (value: VideoFilterType): value is VideoMainSections =>
+    SECTION_VALUES.includes(value as VideoMainSections);
+const isVideoSoftware = (value: VideoFilterType): value is VideoSoftware =>
+    SOFTWARE_VALUES.includes(value as VideoSoftware);
 
 export const fetchVideos = createAsyncThunk<Video[], fetchVideosProps, ThunkConfig<string>>(
     'VideosPage/fetchVideos',
@@ -43,15 +67,26 @@ export const fetchVideos = createAsyncThunk<Video[], fetchVideosProps, ThunkConf
             _sort: sort,
             _order: order,
             q: search,
-            filter: type === VideoType.ALL ? undefined : type,
         };
+
+        if (type !== VideoType.ALL) {
+            if (isVideoType(type)) {
+                params.type = type;
+            } else if (isVideoSection(type)) {
+                params.section = type;
+            } else if (isVideoSoftware(type)) {
+                params.software = type;
+            }
+        }
 
         try {
             addQueryParams({
                 sort,
                 order,
                 search,
-                type: type === VideoType.ALL ? undefined : type,
+                type: params.type,
+                section: params.section,
+                software: params.software,
             });
             const response = await extra.api.get<Video[]>('/api/videos/rutube', {
                 params,

--- a/src/pages/VideosPage/model/services/initVideosPage/initVideosPage.ts
+++ b/src/pages/VideosPage/model/services/initVideosPage/initVideosPage.ts
@@ -1,5 +1,5 @@
 import { createAsyncThunk } from '@reduxjs/toolkit';
-import { VideoSortField, VideoType } from '@/entities/Video';
+import { VideoMainSections, VideoSoftware, VideoSortField, VideoType } from '@/entities/Video';
 import { ThunkConfig } from '@/shared/config/state';
 import { SortOrder } from '@/shared/types/sort';
 import { getVideosPageInited } from '../../selectors/videos';
@@ -16,6 +16,8 @@ export const initVideosPage = createAsyncThunk<void, URLSearchParams, ThunkConfi
         const sortFromUrl = searchParams.get('sort') as VideoSortField;
         const searchFromUrl = searchParams.get('search');
         const typeFromUrl = searchParams.get('type') as VideoType;
+        const sectionFromUrl = searchParams.get('section') as VideoMainSections;
+        const softwareFromUrl = searchParams.get('software') as VideoSoftware;
 
         if (orderFromUrl) {
             dispatch(videoPageActions.setOrder(orderFromUrl));
@@ -28,6 +30,10 @@ export const initVideosPage = createAsyncThunk<void, URLSearchParams, ThunkConfi
         }
         if (typeFromUrl) {
             dispatch(videoPageActions.setType(typeFromUrl));
+        } else if (sectionFromUrl) {
+            dispatch(videoPageActions.setType(sectionFromUrl));
+        } else if (softwareFromUrl) {
+            dispatch(videoPageActions.setType(softwareFromUrl));
         }
 
         if (!inited) {


### PR DESCRIPTION
### Motivation
- Provide a way to manually refresh the RuTube video cache from the admin UI and make RuTube video collection more reliable by improving parsing, deduplication, and including an optional NocoDB source. 
- Reduce cache TTL and add diagnostics to better surface refresh results and sources used.

### Description
- Added a refresh API and controller (`POST /api/videos/rutube/refresh`, `refreshVideosController`) and wired it into server routes and the JSON server (`json-server/videos/videos.routes.ts`, `json-server/index.js`), and also trigger a background refresh on successful `/login` via `refreshRutubeVideosCache()`.
- Reworked the RuTube repository (`json-server/videos/videos.repository.ts`) to provide robust paged fetching (`fetchAllFromPagedEndpoint`), HTML/feed/API endpoint extraction, XML feed parsing, JavaScript/HTML decoding utilities, NocoDB integration via env vars (`NOCODB_*`), deduplication, diagnostics (`getRutubeRefreshDiagnostics`), exposure of `refreshRutubeVideosCache`, and reduced cache TTL/refresh interval.
- Extended types and controllers to support additional query filters (`section` and `software`) and added server-side filtering in `videos.service.ts`, plus type updates (`JsonServerApp.post`) and mapping logic in `videos.controller.ts`.
- Updated frontend to allow manual refresh from admin panel by adding a refresh button and UI (`src/pages/AdminPanelPage/ui/AdminPanelPage.tsx`, styles), and updated video page fetch/init logic to pass `type`, `section`, or `software` filters (`fetchVideos` and `initVideosPage`), along with small routing logic fix for public video route check.

### Testing
- Ran a local TypeScript build and basic dev start to ensure compilation and runtime wiring of new endpoints succeeded. 
- Executed the project's automated test suite (unit/integration) against the changes and the tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d380622a608329957ccacbb76b6856)