### PR TITLE
Add NocoDB-backed instruction links and improve Rutube videos parsing/fallbacks

### DIFF
--- a/json-server/instructions/instructions.controller.ts
+++ b/json-server/instructions/instructions.controller.ts
@@ -100,4 +100,15 @@ export class InstructionsController {
             handleError(`Unable to fetch wiki file: ${slug} -> ${filePath}`, error, res);
         }
     };
+
+    public getExternalLinks = async (_req: JsonServerRequest, res: JsonServerResponse) => {
+        try {
+            const links = await this.service.getExternalLinksFromNoco();
+            res.json(links);
+        } catch (error) {
+            // eslint-disable-next-line no-console
+            console.warn('[instructions] Unable to fetch instruction links from NocoDB, returning empty list', error);
+            res.json([]);
+        }
+    };
 }

--- a/json-server/instructions/instructions.repository.ts
+++ b/json-server/instructions/instructions.repository.ts
@@ -1,4 +1,12 @@
-import { InstructionArticle, InstructionNavNode, WikiFileDto, WikiPageDto } from './types';
+import { request as httpRequest } from 'http';
+import { request as httpsRequest } from 'https';
+import {
+    InstructionArticle,
+    InstructionExternalLink,
+    InstructionNavNode,
+    WikiFileDto,
+    WikiPageDto,
+} from './types';
 import {
     buildInstructionsTree,
     fetchInstructionsIndex,
@@ -15,6 +23,23 @@ import {
 
 const getRootSlug = (): string => String(process.env.YANDEX_WIKI_ROOT_SLUG || '').trim();
 const TREE_CACHE_TTL_MS = 30_000;
+const LINKS_CACHE_TTL_MS = 5 * 60_000;
+const NOCODB_TIMEOUT = 20_000;
+
+const DEFAULT_NOCODB_HOST = 'http://tim.atomsk.ru:3000';
+const DEFAULT_NOCODB_TABLE_ID = 'm2jcg5rzheaqlxw';
+const DEFAULT_NOCODB_VIEW_ID = '';
+
+const NOCODB_HOST = (process.env.NOCODB_HOST || process.env.NOCO_DB_BASE_URL || DEFAULT_NOCODB_HOST).replace(/\/$/, '');
+const NOCODB_TABLE_ID = process.env.NOCODB_INSTRUCTIONS_TABLE_ID
+    || process.env.NOCODB_TABLE_ID
+    || process.env.NOCO_DB_TABLE_ID
+    || DEFAULT_NOCODB_TABLE_ID;
+const NOCODB_VIEW_ID = process.env.NOCODB_INSTRUCTIONS_VIEW_ID
+    || process.env.NOCODB_VIEW_ID
+    || process.env.NOCO_DB_VIEW_ID
+    || DEFAULT_NOCODB_VIEW_ID;
+const NOCODB_API_TOKEN = process.env.NOCODB_API_TOKEN || process.env.NOCO_DB_API_TOKEN || process.env.XC_TOKEN || '';
 
 const logInstructionsStage = (context: string, payload: unknown) => {
     // eslint-disable-next-line no-console
@@ -29,6 +54,161 @@ const logInstructionsWarning = (context: string, payload: unknown) => {
 const isAccessDeniedError = (error: unknown): error is WikiApiError => error instanceof WikiApiError && error.status === 403;
 const isMissingError = (error: unknown): error is WikiApiError => error instanceof WikiApiError && error.status === 404;
 
+type NocoListResponse = {
+    list?: Array<Record<string, unknown>>;
+    pageInfo?: {
+        isLastPage?: boolean;
+    };
+};
+
+const asString = (value: unknown): string => {
+    if (typeof value === 'string') {
+        return value.trim();
+    }
+
+    if (typeof value === 'number' || typeof value === 'boolean') {
+        return String(value).trim();
+    }
+
+    if (Array.isArray(value)) {
+        return value
+            .map((item) => asString(item))
+            .filter(Boolean)
+            .join(' ')
+            .trim();
+    }
+
+    if (value && typeof value === 'object') {
+        const record = value as Record<string, unknown>;
+        return [record.title, record.name, record.label, record.value, record.url, ...Object.values(record)]
+            .map((item) => asString(item))
+            .find(Boolean) || '';
+    }
+
+    return '';
+};
+
+const normalizeKey = (key: string): string =>
+    key
+        .toLowerCase()
+        .replace(/\s+/g, '')
+        .replace(/[()_./\\-]/g, '');
+
+const hasWikiUrl = (value: string): boolean => /^https?:\/\/wiki\.yandex\.ru\//i.test(value);
+
+const pickByKeys = (row: Record<string, unknown>, keys: string[]): string => {
+    const normalizedCandidates = keys.map((key) => normalizeKey(key));
+    const directMatch = Object.entries(row).find(([key, value]) => {
+        const normalized = normalizeKey(key);
+        return normalizedCandidates.includes(normalized) && Boolean(asString(value));
+    });
+
+    if (directMatch) {
+        return asString(directMatch[1]);
+    }
+
+    const partialMatch = Object.entries(row).find(([key, value]) => {
+        const normalized = normalizeKey(key);
+        return normalizedCandidates.some((candidate) => normalized.includes(candidate)) && Boolean(asString(value));
+    });
+
+    return partialMatch ? asString(partialMatch[1]) : '';
+};
+
+const pickWikiUrl = (row: Record<string, unknown>): string => {
+    const preferred = pickByKeys(row, [
+        'url',
+        'URL',
+        'Ссылка',
+        'Ссылка на инструкцию',
+        'Путь к публикации',
+        'Путь к публикации wiki',
+        'wiki',
+    ]);
+
+    if (preferred && hasWikiUrl(preferred)) {
+        return preferred;
+    }
+
+    const detected = Object.values(row)
+        .map((value) => asString(value))
+        .find((value) => hasWikiUrl(value));
+
+    return detected || '';
+};
+
+const pickTitle = (row: Record<string, unknown>): string =>
+    pickByKeys(row, ['Инструкция', 'instruction', 'title', 'Название', 'name']) || 'Инструкция';
+
+const mapWikiUrlToSlug = (url: string): string => {
+    const match = url.match(/^https?:\/\/wiki\.yandex\.ru\/(.+?)\/?$/i);
+
+    if (!match) {
+        return '';
+    }
+
+    try {
+        return decodeURIComponent(match[1]).replace(/^\/+|\/+$/g, '');
+    } catch {
+        return match[1].replace(/^\/+|\/+$/g, '');
+    }
+};
+
+const fetchRaw = async (url: string): Promise<string> =>
+    new Promise((resolve, reject) => {
+        const requester = url.startsWith('https://') ? httpsRequest : httpRequest;
+        const req = requester(
+            url,
+            {
+                method: 'GET',
+                timeout: NOCODB_TIMEOUT,
+                headers: NOCODB_API_TOKEN
+                    ? { 'xc-token': NOCODB_API_TOKEN }
+                    : undefined,
+            },
+            (res) => {
+                const chunks: Buffer[] = [];
+
+                res.on('data', (chunk) => {
+                    chunks.push(Buffer.from(chunk));
+                });
+
+                res.on('end', () => {
+                    const raw = Buffer.concat(chunks).toString('utf8');
+
+                    if (res.statusCode && res.statusCode >= 400) {
+                        reject(new Error(`NocoDB API error ${res.statusCode}: ${raw.slice(0, 180)}`));
+                        return;
+                    }
+
+                    resolve(raw);
+                });
+            },
+        );
+
+        req.on('timeout', () => req.destroy(new Error('NocoDB API timeout')));
+        req.on('error', reject);
+        req.end();
+    });
+
+const fetchJson = async <T>(url: string): Promise<T> => {
+    const raw = await fetchRaw(url);
+    return JSON.parse(raw) as T;
+};
+
+const buildNocoRecordsUrl = (offset: number, limit: number): string => {
+    const params = new URLSearchParams({
+        offset: String(offset),
+        limit: String(limit),
+    });
+
+    if (NOCODB_VIEW_ID) {
+        params.set('viewId', NOCODB_VIEW_ID);
+    }
+
+    return `${NOCODB_HOST}/api/v2/tables/${NOCODB_TABLE_ID}/records?${params.toString()}`;
+};
+
 export class InstructionsRepository {
     private readonly client: YandexWikiClient;
 
@@ -37,6 +217,10 @@ export class InstructionsRepository {
     private readonly articleCache = new Map<string, Promise<WikiPageDto | null>>();
 
     private treeCache: { expiresAt: number; value: Promise<InstructionNavNode[]> } | null = null;
+
+    private linksCache: { expiresAt: number; value: Promise<InstructionExternalLink[]> } | null = null;
+
+    private linksSnapshot: InstructionExternalLink[] = [];
 
     constructor(client: YandexWikiClient) {
         this.client = client;
@@ -232,5 +416,87 @@ export class InstructionsRepository {
             fileName: file.fileName,
         });
         return file;
+    }
+
+    public async getExternalLinksFromNoco(): Promise<InstructionExternalLink[]> {
+        const now = Date.now();
+
+        if (this.linksCache && this.linksCache.expiresAt > now) {
+            return this.linksCache.value;
+        }
+
+        const nextPromise = (async () => {
+            const pageLimit = 25;
+            let offset = 0;
+            let hasMore = true;
+            const rows: Array<Record<string, unknown>> = [];
+
+            while (hasMore) {
+                // eslint-disable-next-line no-await-in-loop
+                const payload = await fetchJson<NocoListResponse>(buildNocoRecordsUrl(offset, pageLimit));
+                const currentRows = Array.isArray(payload.list) ? payload.list : [];
+
+                if (currentRows.length === 0) {
+                    hasMore = false;
+                    break;
+                }
+
+                rows.push(...currentRows);
+                const isLastPage = payload.pageInfo?.isLastPage ?? currentRows.length < pageLimit;
+
+                if (isLastPage) {
+                    hasMore = false;
+                } else {
+                    offset += currentRows.length;
+                }
+            }
+
+            const links = rows
+                .map((row, index) => {
+                    const url = pickWikiUrl(row);
+
+                    if (!url) {
+                        return null;
+                    }
+
+                    const slug = mapWikiUrlToSlug(url);
+
+                    if (!slug) {
+                        return null;
+                    }
+
+                    const rawId = asString(row.Id ?? row.id ?? row.ID ?? row._id) || `noco-link-${index + 1}`;
+                    const title = pickTitle(row);
+
+                    return {
+                        id: rawId,
+                        title,
+                        url,
+                        slug,
+                    } satisfies InstructionExternalLink;
+                })
+                .filter((item): item is InstructionExternalLink => Boolean(item));
+
+            const deduped = Array.from(new Map(links.map((item) => [item.url, item])).values());
+            this.linksSnapshot = deduped;
+            return deduped;
+        })();
+
+        this.linksCache = {
+            expiresAt: now + LINKS_CACHE_TTL_MS,
+            value: nextPromise,
+        };
+
+        try {
+            return await nextPromise;
+        } catch (error) {
+            this.linksCache = null;
+
+            if (this.linksSnapshot.length > 0) {
+                return this.linksSnapshot;
+            }
+
+            throw error;
+        }
     }
 }

--- a/json-server/instructions/instructions.repository.ts
+++ b/json-server/instructions/instructions.repository.ts
@@ -116,7 +116,16 @@ const pickByKeys = (row: Record<string, unknown>, keys: string[]): string => {
 };
 
 const pickWikiUrl = (row: Record<string, unknown>): string => {
+    const fromWikiLink = pickByKeys(row, ['wikiLink', 'WikiLink', 'wikilink']);
+
+    if (fromWikiLink && hasWikiUrl(fromWikiLink)) {
+        return fromWikiLink;
+    }
+
     const preferred = pickByKeys(row, [
+        'wikiLink',
+        'WikiLink',
+        'wikilink',
         'url',
         'URL',
         'Ссылка',
@@ -200,6 +209,7 @@ const buildNocoRecordsUrl = (offset: number, limit: number): string => {
     const params = new URLSearchParams({
         offset: String(offset),
         limit: String(limit),
+        fields: 'Id,id,ID,_id,Инструкция,instruction,title,Название,name,wikiLink,WikiLink,wikilink',
     });
 
     if (NOCODB_VIEW_ID) {

--- a/json-server/instructions/instructions.routes.ts
+++ b/json-server/instructions/instructions.routes.ts
@@ -102,6 +102,17 @@ export const registerInstructionRoutes = (app: JsonServerApp) => {
         }
     });
 
+    app.get('/api/instructions/links', async (req, res) => {
+        try {
+            await getController().getExternalLinks(req, res);
+        } catch (error) {
+            const { status, message } = resolveError(error);
+            // eslint-disable-next-line no-console
+            console.error(`[instructions] ${message}`);
+            res.status(status).json({ message });
+        }
+    });
+
     app.get('/instructions/tree', async (req, res) => {
         try {
             await getController().getTree(req, res);
@@ -123,6 +134,15 @@ export const registerInstructionRoutes = (app: JsonServerApp) => {
     app.get('/instructions/file', async (req, res) => {
         try {
             await getController().getFileByPath(req, res);
+        } catch (error) {
+            const { status, message } = resolveError(error);
+            res.status(status).json({ message });
+        }
+    });
+
+    app.get('/instructions/links', async (req, res) => {
+        try {
+            await getController().getExternalLinks(req, res);
         } catch (error) {
             const { status, message } = resolveError(error);
             res.status(status).json({ message });

--- a/json-server/instructions/instructions.service.ts
+++ b/json-server/instructions/instructions.service.ts
@@ -1,4 +1,4 @@
-import { InstructionArticle, InstructionNavNode, WikiFileDto } from './types';
+import { InstructionArticle, InstructionExternalLink, InstructionNavNode, WikiFileDto } from './types';
 import { InstructionsRepository } from './instructions.repository';
 
 export class InstructionsService {
@@ -18,5 +18,9 @@ export class InstructionsService {
 
     public async getFileByPath(slug: string, filePath: string): Promise<WikiFileDto> {
         return this.repository.getFileByPath(slug, filePath);
+    }
+
+    public async getExternalLinksFromNoco(): Promise<InstructionExternalLink[]> {
+        return this.repository.getExternalLinksFromNoco();
     }
 }

--- a/json-server/instructions/types.ts
+++ b/json-server/instructions/types.ts
@@ -43,6 +43,13 @@ export interface InstructionDataSource {
     articles: InstructionArticle[];
 }
 
+export interface InstructionExternalLink {
+    id: string;
+    title: string;
+    url: string;
+    slug: string;
+}
+
 export interface JsonServerResponse {
     json: (body: unknown) => void;
     status: (code: number) => JsonServerResponse;

--- a/json-server/videos/videos.controller.ts
+++ b/json-server/videos/videos.controller.ts
@@ -1,6 +1,11 @@
 import { JsonServerRequest, JsonServerResponse, VideoDto } from './types';
 import { getVideos } from './videos.service';
-import { getRutubeRefreshDiagnostics, refreshRutubeVideosCache } from './videos.repository';
+import {
+    getCachedRutubeVideosSnapshot,
+    getFallbackVideos,
+    getRutubeRefreshDiagnostics,
+    refreshRutubeVideosCache,
+} from './videos.repository';
 
 const SORT_FIELDS: Array<keyof VideoDto> = ['id', 'title', 'type', 'section', 'software', 'link'];
 const TYPE_VALUES: Array<VideoDto['type']> = ['VIDEO_INSTRUCTION', 'WEBINARS', 'PLUGINS'];
@@ -71,6 +76,36 @@ export const refreshVideosController = async (_req: JsonServerRequest, res: Json
         });
     } catch (error) {
         const message = error instanceof Error ? error.message : 'Unexpected videos refresh error';
+        const cachedVideos = getCachedRutubeVideosSnapshot();
+
+        if (cachedVideos.length > 0) {
+            res.json({
+                success: true,
+                stale: true,
+                fallbackSource: 'cache',
+                count: cachedVideos.length,
+                updatedAt: Date.now(),
+                message,
+                diagnostics: getRutubeRefreshDiagnostics(),
+            });
+            return;
+        }
+
+        const fallbackVideos = getFallbackVideos();
+
+        if (fallbackVideos.length > 0) {
+            res.json({
+                success: true,
+                stale: true,
+                fallbackSource: 'db.json',
+                count: fallbackVideos.length,
+                updatedAt: Date.now(),
+                message,
+                diagnostics: getRutubeRefreshDiagnostics(),
+            });
+            return;
+        }
+
         res.status(500).json({ success: false, message });
     }
 };

--- a/json-server/videos/videos.repository.ts
+++ b/json-server/videos/videos.repository.ts
@@ -73,8 +73,6 @@ const bootstrapCacheFromDisk = () => {
     }
 };
 
-bootstrapCacheFromDisk();
-
 const fetchRaw = async (url: string): Promise<string> =>
     new Promise((resolve, reject) => {
         const requester = url.startsWith('https://') ? httpsRequest : httpRequest;
@@ -139,7 +137,52 @@ type NocoListResponse = {
     };
 };
 
-const asString = (value: unknown): string => (typeof value === 'string' ? value.trim() : '');
+const asString = (value: unknown): string => {
+    if (typeof value === 'string') {
+        return value.trim();
+    }
+
+    if (typeof value === 'number' || typeof value === 'boolean') {
+        return String(value).trim();
+    }
+
+    if (Array.isArray(value)) {
+        return value
+            .map((item) => asString(item))
+            .filter(Boolean)
+            .join(' ')
+            .trim();
+    }
+
+    if (value && typeof value === 'object') {
+        const record = value as Record<string, unknown>;
+        const preferred = [
+            record.title,
+            record.name,
+            record.label,
+            record.value,
+            record.text,
+            record.section,
+            record.Section,
+            record.Раздел,
+        ]
+            .map((item) => asString(item))
+            .find(Boolean);
+
+        if (preferred) {
+            return preferred;
+        }
+
+        return Object.values(record)
+            .map((item) => asString(item))
+            .filter(Boolean)
+            .join(' ')
+            .trim();
+    }
+
+    return '';
+};
+const normalizeText = (value: string): string => value.toLowerCase().replace(/ё/g, 'е');
 
 const normalizeKey = (key: string): string =>
     key
@@ -205,10 +248,45 @@ const pickTitle = (row: Record<string, unknown>): string => {
     return candidate ? asString(candidate[1]) : '';
 };
 
-const mapTitleToType = (title?: string): VideoDto['type'] => {
-    const normalized = (title || '').toLowerCase();
+const pickValueByKeys = (row: Record<string, unknown>, keys: string[]): string => {
+    const normalizedCandidates = keys.map((key) => normalizeKey(key));
 
-    if (normalized.includes('плагин') || normalized.includes('plugin')) {
+    const directMatch = Object.entries(row).find(([key, value]) => {
+        const normalizedKey = normalizeKey(key);
+        return normalizedCandidates.includes(normalizedKey) && Boolean(asString(value));
+    });
+
+    if (directMatch) {
+        return asString(directMatch[1]);
+    }
+
+    const partialMatch = Object.entries(row).find(([key, value]) => {
+        const normalizedKey = normalizeKey(key);
+        return Boolean(asString(value)) && normalizedCandidates.some((candidate) => normalizedKey.includes(candidate));
+    });
+
+    return partialMatch ? asString(partialMatch[1]) : '';
+};
+
+const pickSectionFromRow = (row: Record<string, unknown>): string =>
+    pickValueByKeys(row, [
+        'Раздел',
+        'Section',
+        'section',
+        'Направление',
+        'Discipline',
+        'Дисциплина',
+    ]);
+
+const mapTitleToType = (title?: string): VideoDto['type'] => {
+    const normalized = normalizeText(title || '');
+
+    if (
+        normalized.includes('плагин')
+        || normalized.includes('plugin')
+        || normalized.includes('диспетчер отделки')
+        || normalized.includes('modplus')
+    ) {
         return 'PLUGINS';
     }
 
@@ -218,6 +296,199 @@ const mapTitleToType = (title?: string): VideoDto['type'] => {
 
     return 'VIDEO_INSTRUCTION';
 };
+
+const mapSectionValue = (value?: string): VideoDto['section'] | null => {
+    const normalized = normalizeText(value || '').replace(/\s+/g, '');
+
+    if (!normalized) {
+        return null;
+    }
+
+    if (
+        normalized === 'ар'
+        || normalized === 'ap'
+        || normalized.includes('architect')
+        || normalized.includes('архит')
+    ) {
+        return 'AR';
+    }
+
+    if (
+        normalized === 'кр'
+        || normalized === 'kp'
+        || normalized === 'кж'
+        || normalized.includes('конструк')
+    ) {
+        return 'KR';
+    }
+
+    if (normalized === 'ов' || normalized === 'ob') {
+        return 'OV';
+    }
+
+    if (normalized === 'вк' || normalized === 'bk') {
+        return 'VK';
+    }
+
+    if (normalized === 'эл' || normalized === 'электрика') {
+        return 'EL';
+    }
+
+    if (normalized.includes('common') || normalized.includes('общ')) {
+        return 'COMMON';
+    }
+
+    return null;
+};
+
+const mapTitleToSection = (title?: string): VideoDto['section'] => {
+    const normalized = normalizeText(title || '');
+
+    if (/(^|\W)(кр|kr)(\W|$)/i.test(normalized)) {
+        return 'KR';
+    }
+
+    if (/(^|\W)(ар|ar|ап|ap)(\W|$)/i.test(normalized)) {
+        return 'AR';
+    }
+
+    if (
+        normalized.includes('армирован')
+        || normalized.includes('арматур')
+        || normalized.includes('торцеобразовател')
+        || normalized.includes('чертежей изделий')
+        || normalized.includes('(из)')
+    ) {
+        return 'KR';
+    }
+
+    if (
+        normalized.includes('машино-мест')
+        || normalized.includes('огражден')
+        || normalized.includes('рабочие наборы ар')
+        || normalized.includes('отделк')
+        || normalized.includes('пола')
+        || normalized.includes('кровл')
+        || normalized.includes('фасад')
+        || normalized.includes('фасон')
+        || normalized.includes('архит')
+        || normalized.includes('помещен')
+    ) {
+        return 'AR';
+    }
+
+    if (
+        normalized.includes('вентиляц')
+        || normalized.includes('воздуховод')
+        || normalized.includes('отоплен')
+    ) {
+        return 'OV';
+    }
+
+    if (normalized.includes('канализ') || normalized.includes('водосн') || normalized.includes('труб')) {
+        return 'VK';
+    }
+
+    if (normalized.includes('элект') || normalized.includes('кабел') || normalized.includes('освещ')) {
+        return 'EL';
+    }
+
+    return 'COMMON';
+};
+
+const mapSoftwareValue = (value?: string): VideoDto['software'] | null => {
+    const normalized = normalizeText(value || '').replace(/\s+/g, '');
+
+    if (!normalized) {
+        return null;
+    }
+
+    if (normalized.includes('autocad') || normalized === 'cad') {
+        return 'AUTOCAD';
+    }
+
+    if (normalized.includes('revit')) {
+        return 'REVIT';
+    }
+
+    if (normalized.includes('tangl')) {
+        return 'TANGL_VALUE';
+    }
+
+    if (normalized.includes('civil3d') || normalized.includes('civil')) {
+        return 'CIVIL3D';
+    }
+
+    return null;
+};
+
+const mapTypeValue = (value?: string): VideoDto['type'] | null => {
+    const normalized = normalizeText(value || '').replace(/\s+/g, '');
+
+    if (!normalized) {
+        return null;
+    }
+
+    if (
+        normalized.includes('plugin')
+        || normalized.includes('плагин')
+        || normalized === 'plugins'
+        || normalized === 'plugin'
+    ) {
+        return 'PLUGINS';
+    }
+
+    if (normalized.includes('webinar') || normalized.includes('вебинар')) {
+        return 'WEBINARS';
+    }
+
+    if (
+        normalized.includes('инструк')
+        || normalized.includes('instruction')
+        || normalized.includes('videoinstruction')
+    ) {
+        return 'VIDEO_INSTRUCTION';
+    }
+
+    return null;
+};
+
+const mapTitleToSoftware = (title?: string): VideoDto['software'] => {
+    const normalized = normalizeText(title || '');
+
+    if (normalized.includes('civil 3d') || normalized.includes('civil3d')) {
+        return 'CIVIL3D';
+    }
+
+    if (normalized.includes('наборах характеристик') || normalized.includes('штриховок')) {
+        return 'CIVIL3D';
+    }
+
+    if (normalized.includes('autocad') || normalized.includes('auto cad')) {
+        return 'AUTOCAD';
+    }
+
+    if (normalized.includes('tangl')) {
+        return 'TANGL_VALUE';
+    }
+
+    return 'REVIT';
+};
+
+const enrichVideoByTitle = (video: VideoDto): VideoDto => {
+    const titleBasedType = mapTitleToType(video.title);
+    const titleBasedSection = mapTitleToSection(video.title);
+    const titleBasedSoftware = mapTitleToSoftware(video.title);
+
+    return {
+        ...video,
+        type: video.type && video.type !== 'VIDEO_INSTRUCTION' ? video.type : titleBasedType,
+        section: video.section && video.section !== 'COMMON' ? video.section : titleBasedSection,
+        software: video.software && video.software !== 'REVIT' ? video.software : titleBasedSoftware,
+    };
+};
+
+const normalizeVideosMetadata = (videos: VideoDto[]): VideoDto[] => videos.map(enrichVideoByTitle);
 
 const mapNocoRowToVideo = (row: Record<string, unknown>, index: number): VideoDto | null => {
     const link = pickRutubeLink(row);
@@ -229,15 +500,24 @@ const mapNocoRowToVideo = (row: Record<string, unknown>, index: number): VideoDt
     const title = pickTitle(row) || `Видео ${index + 1}`;
     const rawId = row.Id ?? row.id ?? row.ID ?? row._id;
     const id = String(rawId || `nocodb-${index + 1}`);
+    const typeFromRow = mapTypeValue(
+        pickValueByKeys(row, ['Тип', 'Type', 'Категория', 'Category']),
+    );
+    const sectionFromRow = mapSectionValue(
+        pickSectionFromRow(row),
+    );
+    const softwareFromRow = mapSoftwareValue(
+        pickValueByKeys(row, ['ПО', 'Программа', 'Software', 'Platform']),
+    );
 
-    return {
+    return enrichVideoByTitle({
         id,
         title,
         link,
-        type: mapTitleToType(title),
-        section: 'COMMON',
-        software: 'REVIT',
-    };
+        type: typeFromRow || mapTitleToType(title),
+        section: sectionFromRow || mapTitleToSection(title),
+        software: softwareFromRow || mapTitleToSoftware(title),
+    });
 };
 
 const buildNocoRecordsUrl = (offset: number, limit: number): string => {
@@ -294,10 +574,11 @@ async function loadFreshRutubeVideos(): Promise<VideoDto[]> {
     }
 
     const deduped = Array.from(new Map(videos.map((video) => [video.link, video])).values());
+    const normalized = normalizeVideosMetadata(deduped);
 
-    cachedVideos = deduped;
+    cachedVideos = normalized;
     cacheTimestamp = Date.now();
-    saveVideosCacheToDisk(deduped);
+    saveVideosCacheToDisk(normalized);
 
     lastRefreshDiagnostics = {
         updatedAt: cacheTimestamp,
@@ -311,7 +592,7 @@ async function loadFreshRutubeVideos(): Promise<VideoDto[]> {
         viewId: NOCODB_VIEW_ID,
     };
 
-    return deduped;
+    return normalized;
 }
 
 const scheduleCacheRefresh = () => {
@@ -344,6 +625,8 @@ const refreshInBackgroundIfNeeded = () => {
 
 export const getRutubeVideos = async (): Promise<VideoDto[]> => {
     if (cachedVideos && cachedVideos.length > 0) {
+        cachedVideos = normalizeVideosMetadata(cachedVideos);
+        saveVideosCacheToDisk(cachedVideos);
         refreshInBackgroundIfNeeded();
         return cachedVideos;
     }
@@ -373,11 +656,21 @@ export const refreshRutubeVideosCache = async (): Promise<VideoDto[]> => {
 
 export const getRutubeRefreshDiagnostics = () => lastRefreshDiagnostics;
 
+export const getCachedRutubeVideosSnapshot = (): VideoDto[] => {
+    if (cachedVideos && cachedVideos.length > 0) {
+        return normalizeVideosMetadata(cachedVideos);
+    }
+
+    const diskCache = readVideosCacheFromDisk();
+    return normalizeVideosMetadata(diskCache?.videos || []);
+};
+
 export const getFallbackVideos = (): VideoDto[] => {
     const filePath = path.resolve(__dirname, '../db.json');
     const raw = fs.readFileSync(filePath, 'utf8');
     const db = JSON.parse(raw) as { videos?: VideoDto[] };
-    return db.videos || [];
+    return normalizeVideosMetadata(db.videos || []);
 };
 
+bootstrapCacheFromDisk();
 scheduleCacheRefresh();

--- a/src/entities/Instruction/api/instructionApi.ts
+++ b/src/entities/Instruction/api/instructionApi.ts
@@ -1,5 +1,5 @@
 import { rtqApi } from '@/shared/config/api/rtqApi';
-import { InstructionArticle, InstructionNavNode } from '../model/types/instruction';
+import { InstructionArticle, InstructionExternalLink, InstructionNavNode } from '../model/types/instruction';
 
 const instructionApi = rtqApi.injectEndpoints({
     endpoints: (build) => ({
@@ -13,10 +13,16 @@ const instructionApi = rtqApi.injectEndpoints({
                 url: `/api/instructions/article/${encodeURIComponent(slug)}`,
             }),
         }),
+        getInstructionLinks: build.query<InstructionExternalLink[], void>({
+            query: () => ({
+                url: '/api/instructions/links',
+            }),
+        }),
     }),
 });
 
 export const {
     useGetInstructionTreeQuery,
     useGetInstructionArticleQuery,
+    useGetInstructionLinksQuery,
 } = instructionApi;

--- a/src/entities/Instruction/index.ts
+++ b/src/entities/Instruction/index.ts
@@ -1,11 +1,13 @@
 export {
     useGetInstructionArticleQuery,
+    useGetInstructionLinksQuery,
     useGetInstructionTreeQuery,
 } from './api/instructionApi';
 export type {
     InstructionArticle,
     InstructionArticleItem,
     InstructionBreadcrumb,
+    InstructionExternalLink,
     InstructionNavNode,
     InstructionTocItem,
 } from './model/types/instruction';

--- a/src/entities/Instruction/model/types/instruction.ts
+++ b/src/entities/Instruction/model/types/instruction.ts
@@ -37,3 +37,10 @@ export interface InstructionArticle {
     toc: InstructionTocItem[];
     items: InstructionArticleItem[];
 }
+
+export interface InstructionExternalLink {
+    id: string;
+    title: string;
+    url: string;
+    slug: string;
+}

--- a/src/pages/MainPage/ui/MainPage/MainPage.tsx
+++ b/src/pages/MainPage/ui/MainPage/MainPage.tsx
@@ -3,6 +3,7 @@ import { Page } from '@/shared/ui/redesigned/Page';
 import { MainPageHeader } from '../MainPageHeader/MainPageHeader';
 import { MainPageModelsSection } from '../MainPageModelsSection/MainPageModelsSection';
 import { MainPageSections } from '../MainPageSections/MainPageSections';
+import { MainPageInstructionLinks } from '../MainPageInstructionLinks/MainPageInstructionLinks';
 import { MainPageVideoSection } from '../MainPageVideoSection/MainPageVideoSection';
 import cls from './MainPage.module.scss';
 
@@ -15,6 +16,7 @@ const MainPage = memo(() => {
             <div className={cls.content}>
                 <MainPageHeader />
                 <MainPageSections />
+                <MainPageInstructionLinks />
                 <MainPageVideoSection />
                 <MainPageModelsSection />
                 <hr className={cls.divider} />

--- a/src/pages/MainPage/ui/MainPageInstructionLinks/MainPageInstructionLinks.module.scss
+++ b/src/pages/MainPage/ui/MainPageInstructionLinks/MainPageInstructionLinks.module.scss
@@ -1,0 +1,19 @@
+.linksCard {
+    border: 1px solid var(--color-border);
+    background: var(--card-bg);
+}
+
+.linkRow {
+    padding: 6px 0;
+    border-bottom: 1px dashed var(--color-border);
+}
+
+.linkRow:last-child {
+    border-bottom: none;
+}
+
+.link {
+    font-size: 15px;
+    line-height: 1.35;
+}
+

--- a/src/pages/MainPage/ui/MainPageInstructionLinks/MainPageInstructionLinks.tsx
+++ b/src/pages/MainPage/ui/MainPageInstructionLinks/MainPageInstructionLinks.tsx
@@ -1,0 +1,58 @@
+import { memo } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useGetInstructionLinksQuery } from '@/entities/Instruction';
+import { classNames } from '@/shared/lib/classNames/classNames';
+import { Card } from '@/shared/ui/redesigned/Card';
+import { HStack, VStack } from '@/shared/ui/redesigned/Stack';
+import { Text } from '@/shared/ui/redesigned/Text';
+import cls from './MainPageInstructionLinks.module.scss';
+
+interface MainPageInstructionLinksProps {
+    className?: string;
+}
+
+export const MainPageInstructionLinks = memo((props: MainPageInstructionLinksProps) => {
+    const { className } = props;
+    const { t } = useTranslation();
+    const { data, isLoading } = useGetInstructionLinksQuery();
+
+    return (
+        <Card
+            padding="24"
+            border="round"
+            className={classNames(cls.linksCard, {}, [className])}
+        >
+            <VStack max gap={16}>
+                <VStack gap={8}>
+                    <Text title={t('Инструкции из NocoDB')} size="l" bold />
+                    <Text text={t('Ссылки на статьи Yandex Wiki, доступные для перехода внутри сайта.')} size="s" />
+                </VStack>
+
+                {isLoading && (
+                    <Text text={t('Загрузка ссылок...')} size="s" />
+                )}
+
+                {!isLoading && !data?.length && (
+                    <Text text={t('Ссылки инструкций пока не найдены.')} size="s" />
+                )}
+
+                {!!data?.length && (
+                    <VStack gap={8}>
+                        {data.slice(0, 30).map((item) => (
+                            <HStack key={item.id} max justify="between" className={cls.linkRow}>
+                                <a
+                                    href={item.url}
+                                    target="_blank"
+                                    rel="noreferrer"
+                                    className={cls.link}
+                                >
+                                    {item.title}
+                                </a>
+                            </HStack>
+                        ))}
+                    </VStack>
+                )}
+            </VStack>
+        </Card>
+    );
+});


### PR DESCRIPTION
### Motivation
- Provide a way to surface external instruction links managed in NocoDB so they can be shown in the main UI. 
- Improve robustness of the Rutube videos pipeline by enhancing metadata extraction and adding cache/fallback behavior when refresh fails. 
- Normalize varied NocoDB record shapes and multiple environment variable names to make ingestion more resilient. 

### Description
- Added a new endpoint `GET /api/instructions/links` with controller `getExternalLinks` and service method `getExternalLinksFromNoco`, and a repository implementation `getExternalLinksFromNoco` that pages NocoDB, maps records to `InstructionExternalLink`, deduplicates, and caches results with snapshot fallback. 
- Introduced NocoDB helpers and mapping utilities (`fetchRaw`, `fetchJson`, `pickWikiUrl`, `mapWikiUrlToSlug`, `pickTitle`, normalization helpers) and new env var handling for `NOCODB_*` configuration and token. 
- Frontend: added RTK query endpoint `getInstructionLinks` and hook `useGetInstructionLinksQuery`, new UI component `MainPageInstructionLinks` and styles, and wired it into `MainPage`. 
- Videos: enhanced parsing and enrichment in `videos.repository` with improved `asString`/normalization helpers, smarter mapping of `type`, `section`, and `software`, `normalizeVideosMetadata`, and added `getCachedRutubeVideosSnapshot` and improved fallback logic in `refreshVideosController` to return cached or `db.json` fallback when refresh fails. 

### Testing
- Ran a full TypeScript build and lint check (`yarn build` / `yarn lint`) with no errors. 
- Executed the project's automated unit test suite (`yarn test`) and all tests passed. 
- Manually exercised the new endpoints in dev mode to verify `GET /api/instructions/links` and the videos refresh fallback returned expected JSON when upstream NocoDB/Rutube calls failed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d7078fa7d88329abc3ffbcb2eac317)