### PR TITLE
feat(main): route NocoDB instruction links to internal instruction page

### DIFF
--- a/src/pages/MainPage/ui/MainPageInstructionLinks/MainPageInstructionLinks.tsx
+++ b/src/pages/MainPage/ui/MainPageInstructionLinks/MainPageInstructionLinks.tsx
@@ -1,7 +1,9 @@
 import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useGetInstructionLinksQuery } from '@/entities/Instruction';
+import { useGetInstructionLinksQuery, useGetInstructionTreeQuery } from '@/entities/Instruction';
+import { getRouteInstruction } from '@/shared/const/router';
 import { classNames } from '@/shared/lib/classNames/classNames';
+import { AppLink } from '@/shared/ui/redesigned/AppLink';
 import { Card } from '@/shared/ui/redesigned/Card';
 import { HStack, VStack } from '@/shared/ui/redesigned/Stack';
 import { Text } from '@/shared/ui/redesigned/Text';
@@ -15,6 +17,12 @@ export const MainPageInstructionLinks = memo((props: MainPageInstructionLinksPro
     const { className } = props;
     const { t } = useTranslation();
     const { data, isLoading } = useGetInstructionLinksQuery();
+    const { data: tree = [] } = useGetInstructionTreeQuery();
+
+    const getCategoryBySlug = (slug: string): string | undefined => {
+        const section = tree.find((node) => node.slug === slug || node.children?.some((item) => item.slug === slug));
+        return section?.slug;
+    };
 
     return (
         <Card
@@ -40,14 +48,23 @@ export const MainPageInstructionLinks = memo((props: MainPageInstructionLinksPro
                     <VStack gap={8}>
                         {data.slice(0, 30).map((item) => (
                             <HStack key={item.id} max justify="between" className={cls.linkRow}>
-                                <a
-                                    href={item.url}
-                                    target="_blank"
-                                    rel="noreferrer"
-                                    className={cls.link}
-                                >
-                                    {item.title}
-                                </a>
+                                {item.slug ? (
+                                    <AppLink
+                                        to={getRouteInstruction(item.slug, getCategoryBySlug(item.slug))}
+                                        className={cls.link}
+                                    >
+                                        {item.title}
+                                    </AppLink>
+                                ) : (
+                                    <a
+                                        href={item.url}
+                                        target="_blank"
+                                        rel="noreferrer"
+                                        className={cls.link}
+                                    >
+                                        {item.title}
+                                    </a>
+                                )}
                             </HStack>
                         ))}
                     </VStack>


### PR DESCRIPTION
### Motivation
- Показывать на главной ссылки из NocoDB (`wikiLink`) как переходы внутрь сайта, а не всегда открывать Yandex Wiki в новой вкладке. 
- Для корректной маршрутизации нужно знать категорию (раздел) для `slug` и при отсутствии `slug` сохранять безопасный внешний fallback.

### Description
- В `src/pages/MainPage/ui/MainPageInstructionLinks/MainPageInstructionLinks.tsx` добавлен вызов `useGetInstructionTreeQuery` и импорт `getRouteInstruction` и `AppLink` для построения внутренних ссылок.
- Реализована функция `getCategoryBySlug` для поиска категории раздела по `slug` в дереве инструкций и передача её в `getRouteInstruction`.
- Компонент теперь рендерит внутренний переход через `AppLink` если у записи есть `slug`, и использует внешний `<a href=...>` как fallback когда `slug` отсутствует.

### Testing
- Запущена проверка линтером целевого файла: `npx eslint src/pages/MainPage/ui/MainPageInstructionLinks/MainPageInstructionLinks.tsx` (выполнено успешно).
- Запущен проектный линт `npm run lint:ts -- src/pages/MainPage/ui/MainPageInstructionLinks/MainPageInstructionLinks.tsx`, который запустил ESLint по всему репозиторию и вернул существующие ошибки/предупреждения в других файлах, не связанных с внесённым изменением.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d764062be88329bbcb5a2bc500c839)