### PR TITLE
Add admin-triggered NocoDB instructions refresh with durable 12h cache

### DIFF
--- a/json-server/instructions/instructions.controller.ts
+++ b/json-server/instructions/instructions.controller.ts
@@ -111,4 +111,35 @@ export class InstructionsController {
             res.json([]);
         }
     };
+
+    public refreshExternalLinks = async (_req: JsonServerRequest, res: JsonServerResponse) => {
+        try {
+            const links = await this.service.refreshExternalLinksFromNoco();
+            res.json({
+                success: true,
+                count: links.length,
+                updatedAt: Date.now(),
+            });
+        } catch (error) {
+            const message = error instanceof Error ? error.message : 'Unexpected links refresh error';
+            const cachedLinks = this.service.getCachedExternalLinksSnapshot();
+
+            if (cachedLinks.length > 0) {
+                res.json({
+                    success: true,
+                    stale: true,
+                    fallbackSource: 'cache',
+                    count: cachedLinks.length,
+                    updatedAt: Date.now(),
+                    message,
+                });
+                return;
+            }
+
+            res.status(500).json({
+                success: false,
+                message,
+            });
+        }
+    };
 }

--- a/json-server/instructions/instructions.repository.ts
+++ b/json-server/instructions/instructions.repository.ts
@@ -27,7 +27,7 @@ const getRootSlug = (): string => String(process.env.YANDEX_WIKI_ROOT_SLUG || ''
 const TREE_CACHE_TTL_MS = 30_000;
 const LINKS_CACHE_TTL_MS = 12 * 60 * 60 * 1000;
 const LINKS_REFRESH_INTERVAL_MS = 12 * 60 * 60 * 1000;
-const NOCODB_TIMEOUT = 20_000;
+const NOCODB_TIMEOUT = 8000;
 const LINKS_CACHE_FILE_PATH = path.resolve(__dirname, 'instructions-links-cache.json');
 
 const DEFAULT_NOCODB_HOST = 'http://tim.atomsk.ru:3000';
@@ -94,6 +94,7 @@ const isMissingError = (error: unknown): error is WikiApiError => error instance
 type NocoListResponse = {
     list?: Array<Record<string, unknown>>;
     pageInfo?: {
+        totalRows?: number;
         isLastPage?: boolean;
     };
 };
@@ -155,8 +156,16 @@ const pickByKeys = (row: Record<string, unknown>, keys: string[]): string => {
 const pickWikiUrl = (row: Record<string, unknown>): string => {
     const fromWikiLink = pickByKeys(row, ['wikiLink', 'WikiLink', 'wikilink']);
 
-    if (fromWikiLink && hasWikiUrl(fromWikiLink)) {
-        return fromWikiLink;
+    if (fromWikiLink) {
+        if (hasWikiUrl(fromWikiLink)) {
+            return fromWikiLink;
+        }
+
+        const normalizedSlug = fromWikiLink.replace(/^\/+|\/+$/g, '');
+
+        if (normalizedSlug) {
+            return `https://wiki.yandex.ru/${normalizedSlug}`;
+        }
     }
 
     const preferred = pickByKeys(row, [
@@ -198,6 +207,33 @@ const mapWikiUrlToSlug = (url: string): string => {
     } catch {
         return match[1].replace(/^\/+|\/+$/g, '');
     }
+};
+
+const mapNocoRowToInstructionLink = (
+    row: Record<string, unknown>,
+    index: number,
+): InstructionExternalLink | null => {
+    const url = pickWikiUrl(row);
+
+    if (!url) {
+        return null;
+    }
+
+    const slug = mapWikiUrlToSlug(url);
+
+    if (!slug) {
+        return null;
+    }
+
+    const rawId = asString(row.Id ?? row.id ?? row.ID ?? row._id) || `noco-link-${index + 1}`;
+    const title = pickTitle(row);
+
+    return {
+        id: rawId,
+        title,
+        url,
+        slug,
+    };
 };
 
 const fetchRaw = async (url: string): Promise<string> =>
@@ -255,6 +291,134 @@ const buildNocoRecordsUrl = (offset: number, limit: number): string => {
     return `${NOCODB_HOST}/api/v2/tables/${NOCODB_TABLE_ID}/records?${params.toString()}`;
 };
 
+let cachedExternalLinks: InstructionExternalLink[] | null = null;
+let externalLinksCacheTimestamp = 0;
+let inFlightExternalLinksPromise: Promise<InstructionExternalLink[]> | null = null;
+
+const bootstrapExternalLinksCacheFromDisk = () => {
+    const cache = readLinksCacheFromDisk();
+
+    if (!cache || !Array.isArray(cache.links) || cache.links.length === 0) {
+        return;
+    }
+
+    cachedExternalLinks = cache.links;
+    externalLinksCacheTimestamp = typeof cache.updatedAt === 'number' ? cache.updatedAt : 0;
+};
+
+const loadNocoRows = async (): Promise<Array<Record<string, unknown>>> => {
+    const pageLimit = 200;
+    let offset = 0;
+    const rows: Array<Record<string, unknown>> = [];
+    let hasMore = true;
+
+    while (hasMore) {
+        // eslint-disable-next-line no-await-in-loop
+        const payload = await fetchJson<NocoListResponse>(buildNocoRecordsUrl(offset, pageLimit));
+        const currentRows = Array.isArray(payload.list) ? payload.list : [];
+
+        if (currentRows.length === 0) {
+            hasMore = false;
+        } else {
+            rows.push(...currentRows);
+            const isLastPage = payload.pageInfo?.isLastPage ?? currentRows.length < pageLimit;
+
+            if (isLastPage) {
+                hasMore = false;
+            } else {
+                offset += currentRows.length;
+            }
+        }
+    }
+
+    return rows;
+};
+
+const loadFreshInstructionLinks = async (): Promise<InstructionExternalLink[]> => {
+    const rows = await loadNocoRows();
+    const links = rows
+        .map((row, index) => mapNocoRowToInstructionLink(row, index))
+        .filter((item): item is InstructionExternalLink => Boolean(item));
+
+    if (links.length === 0) {
+        throw new Error('NocoDB returned no usable instruction links');
+    }
+
+    const deduped = Array.from(new Map(links.map((item) => [item.url, item])).values());
+
+    cachedExternalLinks = deduped;
+    externalLinksCacheTimestamp = Date.now();
+    saveLinksCacheToDisk(deduped);
+
+    return deduped;
+};
+
+const scheduleExternalLinksCacheRefresh = () => {
+    setInterval(() => {
+        if (inFlightExternalLinksPromise) {
+            return;
+        }
+
+        inFlightExternalLinksPromise = loadFreshInstructionLinks()
+            .catch(() => cachedExternalLinks || [])
+            .finally(() => {
+                inFlightExternalLinksPromise = null;
+            });
+    }, LINKS_REFRESH_INTERVAL_MS);
+};
+
+const refreshExternalLinksInBackgroundIfNeeded = () => {
+    const cacheIsStale = Date.now() - externalLinksCacheTimestamp >= LINKS_CACHE_TTL_MS;
+
+    if (!cacheIsStale || inFlightExternalLinksPromise) {
+        return;
+    }
+
+    inFlightExternalLinksPromise = loadFreshInstructionLinks()
+        .catch(() => cachedExternalLinks || [])
+        .finally(() => {
+            inFlightExternalLinksPromise = null;
+        });
+};
+
+const getInstructionLinks = async (): Promise<InstructionExternalLink[]> => {
+    if (cachedExternalLinks && cachedExternalLinks.length > 0) {
+        refreshExternalLinksInBackgroundIfNeeded();
+        return cachedExternalLinks;
+    }
+
+    if (inFlightExternalLinksPromise) {
+        return inFlightExternalLinksPromise;
+    }
+
+    inFlightExternalLinksPromise = loadFreshInstructionLinks().finally(() => {
+        inFlightExternalLinksPromise = null;
+    });
+
+    return inFlightExternalLinksPromise;
+};
+
+const refreshInstructionLinksCache = async (): Promise<InstructionExternalLink[]> => {
+    if (inFlightExternalLinksPromise) {
+        return inFlightExternalLinksPromise;
+    }
+
+    inFlightExternalLinksPromise = loadFreshInstructionLinks().finally(() => {
+        inFlightExternalLinksPromise = null;
+    });
+
+    return inFlightExternalLinksPromise;
+};
+
+const getCachedInstructionLinksSnapshot = (): InstructionExternalLink[] => {
+    if (cachedExternalLinks && cachedExternalLinks.length > 0) {
+        return cachedExternalLinks;
+    }
+
+    const diskCache = readLinksCacheFromDisk();
+    return Array.isArray(diskCache?.links) ? diskCache.links : [];
+};
+
 export class InstructionsRepository {
     private readonly client: YandexWikiClient;
 
@@ -264,43 +428,8 @@ export class InstructionsRepository {
 
     private treeCache: { expiresAt: number; value: Promise<InstructionNavNode[]> } | null = null;
 
-    private linksCache: { expiresAt: number; value: Promise<InstructionExternalLink[]> } | null = null;
-
-    private linksSnapshot: InstructionExternalLink[] = [];
-
-    private linksSnapshotUpdatedAt = 0;
-
-    private inFlightLinksPromise: Promise<InstructionExternalLink[]> | null = null;
-
     constructor(client: YandexWikiClient) {
         this.client = client;
-        this.bootstrapLinksFromDisk();
-        this.scheduleLinksCacheRefresh();
-    }
-
-    private bootstrapLinksFromDisk(): void {
-        const cache = readLinksCacheFromDisk();
-
-        if (!cache || !Array.isArray(cache.links) || cache.links.length === 0) {
-            return;
-        }
-
-        this.linksSnapshot = cache.links;
-        this.linksSnapshotUpdatedAt = typeof cache.updatedAt === 'number' ? cache.updatedAt : 0;
-    }
-
-    private scheduleLinksCacheRefresh(): void {
-        setInterval(() => {
-            if (this.inFlightLinksPromise) {
-                return;
-            }
-
-            this.inFlightLinksPromise = this.loadFreshExternalLinksFromNoco()
-                .catch(() => this.linksSnapshot)
-                .finally(() => {
-                    this.inFlightLinksPromise = null;
-                });
-        }, LINKS_REFRESH_INTERVAL_MS);
     }
 
     private async getRootPage(): Promise<WikiPageDto | null> {
@@ -495,132 +624,15 @@ export class InstructionsRepository {
         return file;
     }
 
-    public async getExternalLinksFromNoco(): Promise<InstructionExternalLink[]> {
-        const now = Date.now();
+    // eslint-disable-next-line class-methods-use-this
+    public getExternalLinksFromNoco = async (): Promise<InstructionExternalLink[]> => getInstructionLinks();
 
-        if (this.linksCache && this.linksCache.expiresAt > now) {
-            return this.linksCache.value;
-        }
+    // eslint-disable-next-line class-methods-use-this
+    public refreshExternalLinksFromNoco = async (): Promise<InstructionExternalLink[]> => refreshInstructionLinksCache();
 
-        const cacheIsStale = now - this.linksSnapshotUpdatedAt >= LINKS_CACHE_TTL_MS;
-
-        if (this.linksSnapshot.length > 0 && cacheIsStale && !this.inFlightLinksPromise) {
-            this.inFlightLinksPromise = this.loadFreshExternalLinksFromNoco()
-                .catch(() => this.linksSnapshot)
-                .finally(() => {
-                    this.inFlightLinksPromise = null;
-                });
-        }
-
-        if (this.linksSnapshot.length > 0) {
-            return this.linksSnapshot;
-        }
-
-        return this.refreshExternalLinksFromNoco();
-    }
-
-    public async refreshExternalLinksFromNoco(): Promise<InstructionExternalLink[]> {
-        if (this.inFlightLinksPromise) {
-            return this.inFlightLinksPromise;
-        }
-
-        this.inFlightLinksPromise = this.loadFreshExternalLinksFromNoco().finally(() => {
-            this.inFlightLinksPromise = null;
-        });
-
-        return this.inFlightLinksPromise;
-    }
-
-    public getCachedExternalLinksSnapshot(): InstructionExternalLink[] {
-        if (this.linksSnapshot.length > 0) {
-            return this.linksSnapshot;
-        }
-
-        const cache = readLinksCacheFromDisk();
-        if (!cache || !Array.isArray(cache.links)) {
-            return [];
-        }
-
-        return cache.links;
-    }
-
-    private async loadFreshExternalLinksFromNoco(): Promise<InstructionExternalLink[]> {
-        const now = Date.now();
-
-        const nextPromise = (async () => {
-            const pageLimit = 25;
-            let offset = 0;
-            let hasMore = true;
-            const rows: Array<Record<string, unknown>> = [];
-
-            while (hasMore) {
-                // eslint-disable-next-line no-await-in-loop
-                const payload = await fetchJson<NocoListResponse>(buildNocoRecordsUrl(offset, pageLimit));
-                const currentRows = Array.isArray(payload.list) ? payload.list : [];
-
-                if (currentRows.length === 0) {
-                    hasMore = false;
-                    break;
-                }
-
-                rows.push(...currentRows);
-                const isLastPage = payload.pageInfo?.isLastPage ?? currentRows.length < pageLimit;
-
-                if (isLastPage) {
-                    hasMore = false;
-                } else {
-                    offset += currentRows.length;
-                }
-            }
-
-            const links = rows
-                .map((row, index) => {
-                    const url = pickWikiUrl(row);
-
-                    if (!url) {
-                        return null;
-                    }
-
-                    const slug = mapWikiUrlToSlug(url);
-
-                    if (!slug) {
-                        return null;
-                    }
-
-                    const rawId = asString(row.Id ?? row.id ?? row.ID ?? row._id) || `noco-link-${index + 1}`;
-                    const title = pickTitle(row);
-
-                    return {
-                        id: rawId,
-                        title,
-                        url,
-                        slug,
-                    } satisfies InstructionExternalLink;
-                })
-                .filter((item): item is InstructionExternalLink => Boolean(item));
-
-            const deduped = Array.from(new Map(links.map((item) => [item.url, item])).values());
-            this.linksSnapshot = deduped;
-            this.linksSnapshotUpdatedAt = Date.now();
-            saveLinksCacheToDisk(deduped);
-            return deduped;
-        })();
-
-        this.linksCache = {
-            expiresAt: now + LINKS_CACHE_TTL_MS,
-            value: nextPromise,
-        };
-
-        try {
-            return await nextPromise;
-        } catch (error) {
-            this.linksCache = null;
-
-            if (this.linksSnapshot.length > 0) {
-                return this.linksSnapshot;
-            }
-
-            throw error;
-        }
-    }
+    // eslint-disable-next-line class-methods-use-this
+    public getCachedExternalLinksSnapshot = (): InstructionExternalLink[] => getCachedInstructionLinksSnapshot();
 }
+
+bootstrapExternalLinksCacheFromDisk();
+scheduleExternalLinksCacheRefresh();

--- a/json-server/instructions/instructions.repository.ts
+++ b/json-server/instructions/instructions.repository.ts
@@ -27,12 +27,12 @@ const getRootSlug = (): string => String(process.env.YANDEX_WIKI_ROOT_SLUG || ''
 const TREE_CACHE_TTL_MS = 30_000;
 const LINKS_CACHE_TTL_MS = 12 * 60 * 60 * 1000;
 const LINKS_REFRESH_INTERVAL_MS = 12 * 60 * 60 * 1000;
-const NOCODB_TIMEOUT = 8000;
+const NOCODB_TIMEOUT = 20_000;
 const LINKS_CACHE_FILE_PATH = path.resolve(__dirname, 'instructions-links-cache.json');
 
 const DEFAULT_NOCODB_HOST = 'http://tim.atomsk.ru:3000';
 const DEFAULT_NOCODB_TABLE_ID = 'm2jcg5rzheaqlxw';
-const DEFAULT_NOCODB_VIEW_ID = '';
+const DEFAULT_NOCODB_VIEW_ID = 'vwqbdsi0ekspi90b';
 
 const NOCODB_HOST = (process.env.NOCODB_HOST || process.env.NOCO_DB_BASE_URL || DEFAULT_NOCODB_HOST).replace(/\/$/, '');
 const NOCODB_TABLE_ID = process.env.NOCODB_INSTRUCTIONS_TABLE_ID

--- a/json-server/instructions/instructions.repository.ts
+++ b/json-server/instructions/instructions.repository.ts
@@ -291,21 +291,6 @@ const buildNocoRecordsUrl = (offset: number, limit: number): string => {
     return `${NOCODB_HOST}/api/v2/tables/${NOCODB_TABLE_ID}/records?${params.toString()}`;
 };
 
-let cachedExternalLinks: InstructionExternalLink[] | null = null;
-let externalLinksCacheTimestamp = 0;
-let inFlightExternalLinksPromise: Promise<InstructionExternalLink[]> | null = null;
-
-const bootstrapExternalLinksCacheFromDisk = () => {
-    const cache = readLinksCacheFromDisk();
-
-    if (!cache || !Array.isArray(cache.links) || cache.links.length === 0) {
-        return;
-    }
-
-    cachedExternalLinks = cache.links;
-    externalLinksCacheTimestamp = typeof cache.updatedAt === 'number' ? cache.updatedAt : 0;
-};
-
 const loadNocoRows = async (): Promise<Array<Record<string, unknown>>> => {
     const pageLimit = 200;
     let offset = 0;
@@ -334,91 +319,6 @@ const loadNocoRows = async (): Promise<Array<Record<string, unknown>>> => {
     return rows;
 };
 
-const loadFreshInstructionLinks = async (): Promise<InstructionExternalLink[]> => {
-    const rows = await loadNocoRows();
-    const links = rows
-        .map((row, index) => mapNocoRowToInstructionLink(row, index))
-        .filter((item): item is InstructionExternalLink => Boolean(item));
-
-    if (links.length === 0) {
-        throw new Error('NocoDB returned no usable instruction links');
-    }
-
-    const deduped = Array.from(new Map(links.map((item) => [item.url, item])).values());
-
-    cachedExternalLinks = deduped;
-    externalLinksCacheTimestamp = Date.now();
-    saveLinksCacheToDisk(deduped);
-
-    return deduped;
-};
-
-const scheduleExternalLinksCacheRefresh = () => {
-    setInterval(() => {
-        if (inFlightExternalLinksPromise) {
-            return;
-        }
-
-        inFlightExternalLinksPromise = loadFreshInstructionLinks()
-            .catch(() => cachedExternalLinks || [])
-            .finally(() => {
-                inFlightExternalLinksPromise = null;
-            });
-    }, LINKS_REFRESH_INTERVAL_MS);
-};
-
-const refreshExternalLinksInBackgroundIfNeeded = () => {
-    const cacheIsStale = Date.now() - externalLinksCacheTimestamp >= LINKS_CACHE_TTL_MS;
-
-    if (!cacheIsStale || inFlightExternalLinksPromise) {
-        return;
-    }
-
-    inFlightExternalLinksPromise = loadFreshInstructionLinks()
-        .catch(() => cachedExternalLinks || [])
-        .finally(() => {
-            inFlightExternalLinksPromise = null;
-        });
-};
-
-const getInstructionLinks = async (): Promise<InstructionExternalLink[]> => {
-    if (cachedExternalLinks && cachedExternalLinks.length > 0) {
-        refreshExternalLinksInBackgroundIfNeeded();
-        return cachedExternalLinks;
-    }
-
-    if (inFlightExternalLinksPromise) {
-        return inFlightExternalLinksPromise;
-    }
-
-    inFlightExternalLinksPromise = loadFreshInstructionLinks().finally(() => {
-        inFlightExternalLinksPromise = null;
-    });
-
-    return inFlightExternalLinksPromise;
-};
-
-const refreshInstructionLinksCache = async (): Promise<InstructionExternalLink[]> => {
-    if (inFlightExternalLinksPromise) {
-        return inFlightExternalLinksPromise;
-    }
-
-    inFlightExternalLinksPromise = loadFreshInstructionLinks().finally(() => {
-        inFlightExternalLinksPromise = null;
-    });
-
-    return inFlightExternalLinksPromise;
-};
-
-const getCachedInstructionLinksSnapshot = (): InstructionExternalLink[] => {
-    if (cachedExternalLinks && cachedExternalLinks.length > 0) {
-        return cachedExternalLinks;
-    }
-
-    const diskCache = readLinksCacheFromDisk();
-    return Array.isArray(diskCache?.links) ? diskCache.links : [];
-};
-
 export class InstructionsRepository {
     private readonly client: YandexWikiClient;
 
@@ -428,8 +328,74 @@ export class InstructionsRepository {
 
     private treeCache: { expiresAt: number; value: Promise<InstructionNavNode[]> } | null = null;
 
+    private cachedExternalLinks: InstructionExternalLink[] | null = null;
+
+    private externalLinksCacheTimestamp = 0;
+
+    private inFlightExternalLinksPromise: Promise<InstructionExternalLink[]> | null = null;
+
     constructor(client: YandexWikiClient) {
         this.client = client;
+        this.bootstrapExternalLinksCacheFromDisk();
+        this.scheduleExternalLinksCacheRefresh();
+    }
+
+    private bootstrapExternalLinksCacheFromDisk() {
+        const cache = readLinksCacheFromDisk();
+
+        if (!cache || !Array.isArray(cache.links) || cache.links.length === 0) {
+            return;
+        }
+
+        this.cachedExternalLinks = cache.links;
+        this.externalLinksCacheTimestamp = typeof cache.updatedAt === 'number' ? cache.updatedAt : 0;
+    }
+
+    private scheduleExternalLinksCacheRefresh() {
+        setInterval(() => {
+            if (this.inFlightExternalLinksPromise) {
+                return;
+            }
+
+            this.inFlightExternalLinksPromise = this.loadFreshInstructionLinks()
+                .catch(() => this.cachedExternalLinks || [])
+                .finally(() => {
+                    this.inFlightExternalLinksPromise = null;
+                });
+        }, LINKS_REFRESH_INTERVAL_MS);
+    }
+
+    private async loadFreshInstructionLinks(): Promise<InstructionExternalLink[]> {
+        const rows = await loadNocoRows();
+        const links = rows
+            .map((row, index) => mapNocoRowToInstructionLink(row, index))
+            .filter((item): item is InstructionExternalLink => Boolean(item));
+
+        if (links.length === 0) {
+            throw new Error('NocoDB returned no usable instruction links');
+        }
+
+        const deduped = Array.from(new Map(links.map((item) => [item.url, item])).values());
+
+        this.cachedExternalLinks = deduped;
+        this.externalLinksCacheTimestamp = Date.now();
+        saveLinksCacheToDisk(deduped);
+
+        return deduped;
+    }
+
+    private refreshExternalLinksInBackgroundIfNeeded() {
+        const cacheIsStale = Date.now() - this.externalLinksCacheTimestamp >= LINKS_CACHE_TTL_MS;
+
+        if (!cacheIsStale || this.inFlightExternalLinksPromise) {
+            return;
+        }
+
+        this.inFlightExternalLinksPromise = this.loadFreshInstructionLinks()
+            .catch(() => this.cachedExternalLinks || [])
+            .finally(() => {
+                this.inFlightExternalLinksPromise = null;
+            });
     }
 
     private async getRootPage(): Promise<WikiPageDto | null> {
@@ -624,15 +590,41 @@ export class InstructionsRepository {
         return file;
     }
 
-    // eslint-disable-next-line class-methods-use-this
-    public getExternalLinksFromNoco = async (): Promise<InstructionExternalLink[]> => getInstructionLinks();
+    public async getExternalLinksFromNoco(): Promise<InstructionExternalLink[]> {
+        if (this.cachedExternalLinks && this.cachedExternalLinks.length > 0) {
+            this.refreshExternalLinksInBackgroundIfNeeded();
+            return this.cachedExternalLinks;
+        }
 
-    // eslint-disable-next-line class-methods-use-this
-    public refreshExternalLinksFromNoco = async (): Promise<InstructionExternalLink[]> => refreshInstructionLinksCache();
+        if (this.inFlightExternalLinksPromise) {
+            return this.inFlightExternalLinksPromise;
+        }
 
-    // eslint-disable-next-line class-methods-use-this
-    public getCachedExternalLinksSnapshot = (): InstructionExternalLink[] => getCachedInstructionLinksSnapshot();
+        this.inFlightExternalLinksPromise = this.loadFreshInstructionLinks().finally(() => {
+            this.inFlightExternalLinksPromise = null;
+        });
+
+        return this.inFlightExternalLinksPromise;
+    }
+
+    public async refreshExternalLinksFromNoco(): Promise<InstructionExternalLink[]> {
+        if (this.inFlightExternalLinksPromise) {
+            return this.inFlightExternalLinksPromise;
+        }
+
+        this.inFlightExternalLinksPromise = this.loadFreshInstructionLinks().finally(() => {
+            this.inFlightExternalLinksPromise = null;
+        });
+
+        return this.inFlightExternalLinksPromise;
+    }
+
+    public getCachedExternalLinksSnapshot(): InstructionExternalLink[] {
+        if (this.cachedExternalLinks && this.cachedExternalLinks.length > 0) {
+            return this.cachedExternalLinks;
+        }
+
+        const diskCache = readLinksCacheFromDisk();
+        return Array.isArray(diskCache?.links) ? diskCache.links : [];
+    }
 }
-
-bootstrapExternalLinksCacheFromDisk();
-scheduleExternalLinksCacheRefresh();

--- a/json-server/instructions/instructions.repository.ts
+++ b/json-server/instructions/instructions.repository.ts
@@ -1,3 +1,5 @@
+import fs from 'fs';
+import path from 'path';
 import { request as httpRequest } from 'http';
 import { request as httpsRequest } from 'https';
 import {
@@ -23,8 +25,10 @@ import {
 
 const getRootSlug = (): string => String(process.env.YANDEX_WIKI_ROOT_SLUG || '').trim();
 const TREE_CACHE_TTL_MS = 30_000;
-const LINKS_CACHE_TTL_MS = 5 * 60_000;
+const LINKS_CACHE_TTL_MS = 12 * 60 * 60 * 1000;
+const LINKS_REFRESH_INTERVAL_MS = 12 * 60 * 60 * 1000;
 const NOCODB_TIMEOUT = 20_000;
+const LINKS_CACHE_FILE_PATH = path.resolve(__dirname, 'instructions-links-cache.json');
 
 const DEFAULT_NOCODB_HOST = 'http://tim.atomsk.ru:3000';
 const DEFAULT_NOCODB_TABLE_ID = 'm2jcg5rzheaqlxw';
@@ -40,6 +44,39 @@ const NOCODB_VIEW_ID = process.env.NOCODB_INSTRUCTIONS_VIEW_ID
     || process.env.NOCO_DB_VIEW_ID
     || DEFAULT_NOCODB_VIEW_ID;
 const NOCODB_API_TOKEN = process.env.NOCODB_API_TOKEN || process.env.NOCO_DB_API_TOKEN || process.env.XC_TOKEN || '';
+
+type InstructionLinksCacheFile = {
+    updatedAt?: number;
+    links?: InstructionExternalLink[];
+};
+
+const readLinksCacheFromDisk = (): InstructionLinksCacheFile | null => {
+    try {
+        if (!fs.existsSync(LINKS_CACHE_FILE_PATH)) {
+            return null;
+        }
+
+        const raw = fs.readFileSync(LINKS_CACHE_FILE_PATH, 'utf8');
+        return JSON.parse(raw) as InstructionLinksCacheFile;
+    } catch {
+        return null;
+    }
+};
+
+const saveLinksCacheToDisk = (links: InstructionExternalLink[]): void => {
+    try {
+        fs.writeFileSync(
+            LINKS_CACHE_FILE_PATH,
+            JSON.stringify({
+                updatedAt: Date.now(),
+                links,
+            }),
+            'utf8',
+        );
+    } catch {
+        // noop
+    }
+};
 
 const logInstructionsStage = (context: string, payload: unknown) => {
     // eslint-disable-next-line no-console
@@ -209,7 +246,6 @@ const buildNocoRecordsUrl = (offset: number, limit: number): string => {
     const params = new URLSearchParams({
         offset: String(offset),
         limit: String(limit),
-        fields: 'Id,id,ID,_id,Инструкция,instruction,title,Название,name,wikiLink,WikiLink,wikilink',
     });
 
     if (NOCODB_VIEW_ID) {
@@ -232,8 +268,39 @@ export class InstructionsRepository {
 
     private linksSnapshot: InstructionExternalLink[] = [];
 
+    private linksSnapshotUpdatedAt = 0;
+
+    private inFlightLinksPromise: Promise<InstructionExternalLink[]> | null = null;
+
     constructor(client: YandexWikiClient) {
         this.client = client;
+        this.bootstrapLinksFromDisk();
+        this.scheduleLinksCacheRefresh();
+    }
+
+    private bootstrapLinksFromDisk(): void {
+        const cache = readLinksCacheFromDisk();
+
+        if (!cache || !Array.isArray(cache.links) || cache.links.length === 0) {
+            return;
+        }
+
+        this.linksSnapshot = cache.links;
+        this.linksSnapshotUpdatedAt = typeof cache.updatedAt === 'number' ? cache.updatedAt : 0;
+    }
+
+    private scheduleLinksCacheRefresh(): void {
+        setInterval(() => {
+            if (this.inFlightLinksPromise) {
+                return;
+            }
+
+            this.inFlightLinksPromise = this.loadFreshExternalLinksFromNoco()
+                .catch(() => this.linksSnapshot)
+                .finally(() => {
+                    this.inFlightLinksPromise = null;
+                });
+        }, LINKS_REFRESH_INTERVAL_MS);
     }
 
     private async getRootPage(): Promise<WikiPageDto | null> {
@@ -435,6 +502,51 @@ export class InstructionsRepository {
             return this.linksCache.value;
         }
 
+        const cacheIsStale = now - this.linksSnapshotUpdatedAt >= LINKS_CACHE_TTL_MS;
+
+        if (this.linksSnapshot.length > 0 && cacheIsStale && !this.inFlightLinksPromise) {
+            this.inFlightLinksPromise = this.loadFreshExternalLinksFromNoco()
+                .catch(() => this.linksSnapshot)
+                .finally(() => {
+                    this.inFlightLinksPromise = null;
+                });
+        }
+
+        if (this.linksSnapshot.length > 0) {
+            return this.linksSnapshot;
+        }
+
+        return this.refreshExternalLinksFromNoco();
+    }
+
+    public async refreshExternalLinksFromNoco(): Promise<InstructionExternalLink[]> {
+        if (this.inFlightLinksPromise) {
+            return this.inFlightLinksPromise;
+        }
+
+        this.inFlightLinksPromise = this.loadFreshExternalLinksFromNoco().finally(() => {
+            this.inFlightLinksPromise = null;
+        });
+
+        return this.inFlightLinksPromise;
+    }
+
+    public getCachedExternalLinksSnapshot(): InstructionExternalLink[] {
+        if (this.linksSnapshot.length > 0) {
+            return this.linksSnapshot;
+        }
+
+        const cache = readLinksCacheFromDisk();
+        if (!cache || !Array.isArray(cache.links)) {
+            return [];
+        }
+
+        return cache.links;
+    }
+
+    private async loadFreshExternalLinksFromNoco(): Promise<InstructionExternalLink[]> {
+        const now = Date.now();
+
         const nextPromise = (async () => {
             const pageLimit = 25;
             let offset = 0;
@@ -489,6 +601,8 @@ export class InstructionsRepository {
 
             const deduped = Array.from(new Map(links.map((item) => [item.url, item])).values());
             this.linksSnapshot = deduped;
+            this.linksSnapshotUpdatedAt = Date.now();
+            saveLinksCacheToDisk(deduped);
             return deduped;
         })();
 

--- a/json-server/instructions/instructions.routes.ts
+++ b/json-server/instructions/instructions.routes.ts
@@ -148,4 +148,24 @@ export const registerInstructionRoutes = (app: JsonServerApp) => {
             res.status(status).json({ message });
         }
     });
+
+    app.post('/api/instructions/links/refresh', async (req, res) => {
+        try {
+            await getController().refreshExternalLinks(req, res);
+        } catch (error) {
+            const { status, message } = resolveError(error);
+            // eslint-disable-next-line no-console
+            console.error(`[instructions] ${message}`);
+            res.status(status).json({ message });
+        }
+    });
+
+    app.post('/instructions/links/refresh', async (req, res) => {
+        try {
+            await getController().refreshExternalLinks(req, res);
+        } catch (error) {
+            const { status, message } = resolveError(error);
+            res.status(status).json({ message });
+        }
+    });
 };

--- a/json-server/instructions/instructions.service.ts
+++ b/json-server/instructions/instructions.service.ts
@@ -23,4 +23,12 @@ export class InstructionsService {
     public async getExternalLinksFromNoco(): Promise<InstructionExternalLink[]> {
         return this.repository.getExternalLinksFromNoco();
     }
+
+    public async refreshExternalLinksFromNoco(): Promise<InstructionExternalLink[]> {
+        return this.repository.refreshExternalLinksFromNoco();
+    }
+
+    public getCachedExternalLinksSnapshot(): InstructionExternalLink[] {
+        return this.repository.getCachedExternalLinksSnapshot();
+    }
 }

--- a/json-server/instructions/types.ts
+++ b/json-server/instructions/types.ts
@@ -65,6 +65,7 @@ export interface JsonServerRequest {
 
 export interface JsonServerApp {
     get: (path: string, handler: (req: JsonServerRequest, res: JsonServerResponse) => void | Promise<void>) => void;
+    post: (path: string, handler: (req: JsonServerRequest, res: JsonServerResponse) => void | Promise<void>) => void;
 }
 
 export interface WikiPageDto {

--- a/src/pages/AdminPanelPage/ui/AdminPanelPage.tsx
+++ b/src/pages/AdminPanelPage/ui/AdminPanelPage.tsx
@@ -15,11 +15,21 @@ interface RefreshVideosResponse {
     message?: string;
 }
 
+interface RefreshInstructionLinksResponse {
+    success: boolean;
+    count?: number;
+    updatedAt?: number;
+    message?: string;
+}
+
 const AdminPanelPage = memo(() => {
     const { t } = useTranslation();
     const [isRefreshing, setIsRefreshing] = useState(false);
     const [refreshError, setRefreshError] = useState<string | null>(null);
     const [refreshSuccess, setRefreshSuccess] = useState<string | null>(null);
+    const [isRefreshingInstructionLinks, setIsRefreshingInstructionLinks] = useState(false);
+    const [instructionLinksError, setInstructionLinksError] = useState<string | null>(null);
+    const [instructionLinksSuccess, setInstructionLinksSuccess] = useState<string | null>(null);
     const canRefreshVideos = useSelector(isUserAdmin);
 
     const onRefreshVideos = useCallback(async () => {
@@ -44,17 +54,51 @@ const AdminPanelPage = memo(() => {
         }
     }, [t]);
 
+    const onRefreshInstructionLinks = useCallback(async () => {
+        setIsRefreshingInstructionLinks(true);
+        setInstructionLinksError(null);
+        setInstructionLinksSuccess(null);
+
+        try {
+            const response = await $api.post<RefreshInstructionLinksResponse>('/api/instructions/links/refresh');
+
+            if (response.data.success) {
+                const count = response.data.count ?? 0;
+                setInstructionLinksSuccess(t('Кеш инструкций обновлен. Найдено ссылок: {{count}}', { count }));
+            } else {
+                setInstructionLinksError(response.data.message || t('Не удалось обновить кеш инструкций'));
+            }
+        } catch (error) {
+            const message = error instanceof Error ? error.message : t('Не удалось обновить кеш инструкций');
+            setInstructionLinksError(message);
+        } finally {
+            setIsRefreshingInstructionLinks(false);
+        }
+    }, [t]);
+
     return (
         <Page data-testid="AdminPanelPage" className={cls.AdminPanelPage}>
             <Text title={t('AdminPanelPage')} />
             {canRefreshVideos && (
-                <div className={cls.refreshVideos}>
-                    <Button onClick={onRefreshVideos} disabled={isRefreshing}>
-                        {isRefreshing ? t('Обновляем видео...') : t('Обновить видео с RuTube')}
-                    </Button>
-                    {refreshSuccess && <Text text={refreshSuccess} />}
-                    {refreshError && <Text variant="error" text={refreshError} />}
-                </div>
+                <>
+                    <div className={cls.refreshVideos}>
+                        <Button onClick={onRefreshVideos} disabled={isRefreshing}>
+                            {isRefreshing ? t('Обновляем видео...') : t('Обновить видео с RuTube')}
+                        </Button>
+                        {refreshSuccess && <Text text={refreshSuccess} />}
+                        {refreshError && <Text variant="error" text={refreshError} />}
+                    </div>
+
+                    <div className={cls.refreshVideos}>
+                        <Button onClick={onRefreshInstructionLinks} disabled={isRefreshingInstructionLinks}>
+                            {isRefreshingInstructionLinks
+                                ? t('Обновляем инструкции...')
+                                : t('Обновить инструкции из NocoDB')}
+                        </Button>
+                        {instructionLinksSuccess && <Text text={instructionLinksSuccess} />}
+                        {instructionLinksError && <Text variant="error" text={instructionLinksError} />}
+                    </div>
+                </>
             )}
         </Page>
     );


### PR DESCRIPTION
### Motivation
- Make NocoDB-backed instruction links reliable and allow admins to force-refresh the links cache from the admin UI. 
- Provide a durable local fallback when NocoDB is unavailable and avoid repeated empty responses caused by a restrictive NocoDB `fields` query. 

### Description
- Added an admin button `Обновить инструкции из NocoDB` to the admin panel that calls a new endpoint to force-refresh instruction links; UI changes are in `src/pages/AdminPanelPage/ui/AdminPanelPage.tsx`. 
- Exposed a new POST endpoint `POST /api/instructions/links/refresh` (and alias `/instructions/links/refresh`) and a controller action `refreshExternalLinks` that returns success/stale fallback responses; changes in `json-server/instructions/instructions.routes.ts` and `json-server/instructions/instructions.controller.ts`. 
- Implemented a durable 12-hour links cache with disk persistence (`instructions-links-cache.json`), background refresh every 12 hours, bootstrap-from-disk on startup, stale-cache background refresh and explicit refresh API in `json-server/instructions/instructions.repository.ts`, and added service methods in `json-server/instructions/instructions.service.ts`. 
- Fixed likely NocoDB loading issue by removing the restrictive `fields` parameter from `buildNocoRecordsUrl` so the flexible key-detection logic can find URL/title columns regardless of column names. 
- Added `post` to the `JsonServerApp` type to allow typed POST route registration in `json-server/instructions/types.ts`.

### Testing
- Linted the modified instruction files with `npx eslint json-server/instructions/instructions.repository.ts json-server/instructions/instructions.service.ts json-server/instructions/instructions.controller.ts json-server/instructions/instructions.routes.ts json-server/instructions/types.ts src/pages/AdminPanelPage/ui/AdminPanelPage.tsx` which completed without errors for those files. 
- Ran repository lint `npm run lint:ts -- --max-warnings=0` which failed due to pre-existing, unrelated lint errors elsewhere in the repo (not introduced by this change). 
- Verified the changes compile and committed the patch (`Add admin refresh for Noco instructions and 12h links cache`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d768575330832995bfe73928472c9b)